### PR TITLE
Add LangChain trivia service powered by local LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ A simple FastAPI backend is located in the `backend/` directory. The configurati
 
 The server exposes a sample endpoint at `/api/hello` returning a welcome message.
 
+### Trivia Chain Demo
+
+The backend now includes a simple [LangChain](https://python.langchain.com) setup
+that uses a local LLM provided by [Ollama](https://ollama.ai). A small knowledge
+base lives in `backend/data/trivia.md` and is loaded into a vector store on
+startup. When Ollama is running locally, you can query this data via:
+
+```bash
+curl "http://localhost:8000/api/trivia?q=What is the largest planet?"
+```
+
+Make sure to install the new Python dependencies and have an Ollama model (for
+example `llama3`) available.
+
 
 ## Console Service
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .config import Settings
 from .services.example_service import router as example_router
+from .services.trivia_service import router as trivia_router
 
 settings = Settings()
 
@@ -16,3 +17,4 @@ app.add_middleware(
 )
 
 app.include_router(example_router, prefix="/api")
+app.include_router(trivia_router, prefix="/api")

--- a/backend/app/services/trivia_service.py
+++ b/backend/app/services/trivia_service.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Query
+from langchain.chains import RetrievalQA
+from langchain_community.document_loaders import UnstructuredMarkdownLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.vectorstores import Chroma
+from langchain_community.embeddings import OllamaEmbeddings
+from langchain_community.llms import Ollama
+
+router = APIRouter()
+
+DATA_FILE = Path(__file__).resolve().parents[1] / "data" / "trivia.md"
+
+
+def _create_chain() -> RetrievalQA:
+    loader = UnstructuredMarkdownLoader(str(DATA_FILE))
+    docs = loader.load()
+    splitter = RecursiveCharacterTextSplitter(chunk_size=512, chunk_overlap=50)
+    splits = splitter.split_documents(docs)
+
+    embeddings = OllamaEmbeddings(model="nomic-embed-text")
+    vectorstore = Chroma.from_documents(splits, embeddings)
+    llm = Ollama(model="llama3")
+    return RetrievalQA.from_chain_type(llm=llm, retriever=vectorstore.as_retriever())
+
+
+_CHAIN: RetrievalQA | None = None
+
+
+def get_chain() -> RetrievalQA:
+    global _CHAIN
+    if _CHAIN is None:
+        _CHAIN = _create_chain()
+    return _CHAIN
+
+
+@router.get("/trivia")
+def ask_trivia(q: str = Query(..., description="Question for the trivia bot")):
+    try:
+        answer = get_chain().run(q)
+    except Exception as exc:  # pragma: no cover - runtime failure
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"answer": answer}

--- a/backend/data/trivia.md
+++ b/backend/data/trivia.md
@@ -1,0 +1,6 @@
+# Trivia Knowledge
+
+- The tallest mountain in the world is Mount Everest at 8,848 meters.
+- The largest ocean on Earth is the Pacific Ocean.
+- Jupiter is the biggest planet in our Solar System.
+- The capital city of France is Paris.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,9 @@ fastapi
 uvicorn
 pydantic
 pydantic-settings
+langchain
+langchain-community
+chromadb
+ollama
+unstructured
+markdown


### PR DESCRIPTION
## Summary
- integrate LangChain with a simple FastAPI service
- provide trivia markdown data
- expose `/api/trivia` endpoint
- document how to query the endpoint
- update Python dependencies

## Testing
- `cd backend && python -m app.main & sleep 3; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68814ea936808333a9a0a9e016b9936f