### PR TITLE
Add FastAPI auth and local LLM agent

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -2,8 +2,12 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import Settings
+from .db import Base, engine
 from .services.example_service import router as example_router
 from .services.trivia_service import router as trivia_router
+from .services.auth_service import router as auth_router
+from .services.user_service import router as user_router
+from .services.agent_service import router as agent_router
 
 settings = Settings()
 
@@ -16,5 +20,11 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Ensure database tables exist
+Base.metadata.create_all(bind=engine)
+
 app.include_router(example_router, prefix="/api")
 app.include_router(trivia_router, prefix="/api")
+app.include_router(auth_router, prefix="/api")
+app.include_router(user_router, prefix="/api")
+app.include_router(agent_router, prefix="/api")

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+Base = declarative_base()

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,27 @@
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .db import SessionLocal
+from .models import User
+from .security import oauth2_scheme, decode_access_token
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_current_user(
+    db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)
+) -> User:
+    payload = decode_access_token(token)
+    username: str | None = payload.get("sub")
+    if username is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+    user = db.query(User).filter(User.username == username).first()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    return user

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+
+from .db import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+class UserBase(BaseModel):
+    username: str
+
+class UserCreate(UserBase):
+    password: str
+
+class UserRead(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+SECRET_KEY = "super-secret-key"  # In production use environment variable
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/auth/login")
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+def decode_access_token(token: str) -> dict:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        return payload
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")

--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, HTTPException, Body
+from langchain.agents import create_sql_agent
+from langchain_community.utilities import SQLDatabase
+from langchain_community.llms import Ollama
+
+from ..db import engine
+
+router = APIRouter(tags=["agent"], prefix="/agent")
+
+_AGENT = None
+
+def get_agent():
+    global _AGENT
+    if _AGENT is None:
+        db = SQLDatabase(engine)
+        llm = Ollama(model="llama3")
+        _AGENT = create_sql_agent(llm=llm, db=db, agent_type="openai-tools")
+    return _AGENT
+
+
+@router.post("/run")
+def run_agent(command: str = Body(..., embed=True)):
+    try:
+        result = get_agent().invoke({"input": command})
+        return {"response": result["output"]}
+    except Exception as exc:  # pragma: no cover - runtime failure
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas, security, dependencies
+
+router = APIRouter(tags=["auth"], prefix="/auth")
+
+
+@router.post("/register", response_model=schemas.UserRead)
+def register(user: schemas.UserCreate, db: Session = Depends(dependencies.get_db)):
+    existing = db.query(models.User).filter(models.User.username == user.username).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    hashed = security.get_password_hash(user.password)
+    db_user = models.User(username=user.username, hashed_password=hashed)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@router.post("/login")
+def login(user: schemas.UserCreate, db: Session = Depends(dependencies.get_db)):
+    db_user = db.query(models.User).filter(models.User.username == user.username).first()
+    if not db_user or not security.verify_password(user.password, db_user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    token = security.create_access_token({"sub": db_user.username})
+    return {"access_token": token, "token_type": "bearer"}

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, Depends
+
+from .. import schemas, dependencies
+
+router = APIRouter(tags=["user"], prefix="/user")
+
+
+@router.get("/me", response_model=schemas.UserRead)
+def read_me(current_user = Depends(dependencies.get_current_user)):
+    return current_user

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,7 @@ chromadb
 ollama
 unstructured
 markdown
+sqlalchemy
+passlib[bcrypt]
+python-jose[cryptography]
+langchain-experimental


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and DB setup
- create JWT-based auth endpoints for register & login
- expose user profile endpoint
- integrate LangChain SQL agent using Ollama
- install required backend dependencies

## Testing
- `pip install -r backend/requirements.txt`
- `python -m backend.app.main` *(fails: Error loading ASGI app)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688152877e38833390eed5a5b16c6482