### PR TITLE
Add chat caching and Celery summarization worker

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -2,8 +2,13 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import Settings
+from .db import Base, engine
 from .services.example_service import router as example_router
 from .services.trivia_service import router as trivia_router
+from .services.auth_service import router as auth_router
+from .services.user_service import router as user_router
+from .services.agent_service import router as agent_router
+from .services.chat_service import router as chat_router
 
 settings = Settings()
 
@@ -16,5 +21,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Ensure database tables exist
+Base.metadata.create_all(bind=engine)
+
 app.include_router(example_router, prefix="/api")
 app.include_router(trivia_router, prefix="/api")
+app.include_router(auth_router, prefix="/api")
+app.include_router(user_router, prefix="/api")
+app.include_router(agent_router, prefix="/api")
+app.include_router(chat_router, prefix="/api")

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+Base = declarative_base()

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,27 @@
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .db import SessionLocal
+from .models import User
+from .security import oauth2_scheme, decode_access_token
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_current_user(
+    db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)
+) -> User:
+    payload = decode_access_token(token)
+    username: str | None = payload.get("sub")
+    if username is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+    user = db.query(User).filter(User.username == username).first()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    return user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 if __name__ == "__main__":
     logger.info("Starting %s", settings.app_name)
     run(
-        "app:app",
+        "backend.app:app",
         host=settings.host,
         port=settings.port,
         reload=settings.debug,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+
+from .db import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+class UserBase(BaseModel):
+    username: str
+
+class UserCreate(UserBase):
+    password: str
+
+class UserRead(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+SECRET_KEY = "super-secret-key"  # In production use environment variable
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/auth/login")
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+def decode_access_token(token: str) -> dict:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        return payload
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")

--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, HTTPException, Body
+from langchain.agents import create_sql_agent
+from langchain_community.utilities import SQLDatabase
+from langchain_community.llms import Ollama
+from langchain_experimental.sql import SQLDatabaseChain
+
+from ..db import engine
+
+router = APIRouter(tags=["agent"], prefix="/agent")
+
+_AGENT = None
+_CHAIN = None
+
+def get_agent():
+    global _AGENT
+    if _AGENT is None:
+        db = SQLDatabase(engine)
+        llm = Ollama(model="llama3")
+        _AGENT = create_sql_agent(llm=llm, db=db, agent_type="openai-tools")
+    return _AGENT
+
+
+def get_chain():
+    global _CHAIN
+    if _CHAIN is None:
+        db = SQLDatabase(engine)
+        llm = Ollama(model="llama3")
+        _CHAIN = SQLDatabaseChain.from_llm(llm, db, return_intermediate_steps=True)
+    return _CHAIN
+
+
+@router.post("/run")
+def run_agent(command: str = Body(..., embed=True)):
+    try:
+        result = get_agent().invoke({"input": command})
+        return {"response": result["output"]}
+    except Exception as exc:  # pragma: no cover - runtime failure
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.post("/sql")
+def run_sql(question: str = Body(..., embed=True)):
+    try:
+        result = get_chain().invoke({"question": question})
+        return {
+            "answer": result.get("result"),
+            "sql": result.get("intermediate_steps", [{}])[-1].get("query") if result.get("intermediate_steps") else None,
+        }
+    except Exception as exc:  # pragma: no cover - runtime failure
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas, security, dependencies
+
+router = APIRouter(tags=["auth"], prefix="/auth")
+
+
+@router.post("/register", response_model=schemas.UserRead)
+def register(user: schemas.UserCreate, db: Session = Depends(dependencies.get_db)):
+    existing = db.query(models.User).filter(models.User.username == user.username).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    hashed = security.get_password_hash(user.password)
+    db_user = models.User(username=user.username, hashed_password=hashed)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@router.post("/login")
+def login(user: schemas.UserCreate, db: Session = Depends(dependencies.get_db)):
+    db_user = db.query(models.User).filter(models.User.username == user.username).first()
+    if not db_user or not security.verify_password(user.password, db_user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    token = security.create_access_token({"sub": db_user.username})
+    return {"access_token": token, "token_type": "bearer"}

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from fastapi import APIRouter, Body, HTTPException
+from langchain_community.llms import Ollama
+
+router = APIRouter(tags=["chat"], prefix="/chat")
+
+_CACHE_FILE = Path(__file__).resolve().parents[1] / "data" / "chat_cache.json"
+_llm: Ollama | None = None
+
+
+def _load_cache() -> dict[str, str]:
+    if _CACHE_FILE.exists():
+        try:
+            return json.loads(_CACHE_FILE.read_text())
+        except json.JSONDecodeError:  # pragma: no cover - corrupted file
+            return {}
+    return {}
+
+
+def _save_cache(cache: dict[str, str]) -> None:
+    _CACHE_FILE.write_text(json.dumps(cache))
+
+
+def get_llm() -> Ollama:
+    global _llm
+    if _llm is None:
+        _llm = Ollama(model="llama3")
+    return _llm
+
+
+@router.post("")
+def chat(message: str = Body(..., embed=True)):
+    cache = _load_cache()
+    if message in cache:
+        return {"response": cache[message], "cached": True}
+    try:
+        response = get_llm().invoke(message)
+    except Exception as exc:  # pragma: no cover - runtime failure
+        raise HTTPException(status_code=500, detail=str(exc))
+    cache[message] = response
+    _save_cache(cache)
+    return {"response": response, "cached": False}

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, Depends
+
+from .. import schemas, dependencies
+
+router = APIRouter(tags=["user"], prefix="/user")
+
+
+@router.get("/me", response_model=schemas.UserRead)
+def read_me(current_user = Depends(dependencies.get_current_user)):
+    return current_user

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from celery import Celery
+from langchain_community.llms import Ollama
+
+from .db import SessionLocal
+from .models import User
+
+celery_app = Celery("worker", broker="redis://localhost:6379/0")
+
+_STATE_FILE = Path(__file__).resolve().parents[1] / "data" / "summary_state.json"
+_SUMMARY_FILE = Path(__file__).resolve().parents[1] / "data" / "user_summaries.json"
+
+
+def _read_json(path: Path) -> dict | list | int | str:
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except json.JSONDecodeError:  # pragma: no cover - corrupted file
+            return {}
+    return {}
+
+
+def _write_json(path: Path, data) -> None:
+    path.write_text(json.dumps(data))
+
+
+@celery_app.on_after_configure.connect
+def setup_periodic_tasks(sender, **kwargs):
+    sender.add_periodic_task(60.0, summarize_new_users.s())
+
+
+@celery_app.task
+def summarize_new_users():
+    state = _read_json(_STATE_FILE)
+    last_id = state.get("last_id", 0)
+    db = SessionLocal()
+    try:
+        users = db.query(User).filter(User.id > last_id).order_by(User.id).all()
+    finally:
+        db.close()
+    if not users:
+        return "No new users"
+
+    llm = Ollama(model="llama3")
+    content = "\n".join(u.username for u in users)
+    summary = llm.invoke(f"Summarize the following new users:\n{content}")
+
+    summaries = _read_json(_SUMMARY_FILE) or []
+    summaries.append({"users": [u.id for u in users], "summary": summary})
+    _write_json(_SUMMARY_FILE, summaries)
+    _write_json(_STATE_FILE, {"last_id": users[-1].id})
+    return summary

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,9 @@ chromadb
 ollama
 unstructured
 markdown
+sqlalchemy
+passlib[bcrypt]
+python-jose[cryptography]
+langchain-experimental
+celery
+redis


### PR DESCRIPTION
## Summary
- serve chat responses via LangChain with local caching
- add Celery worker summarizing new users using Ollama
- expose SQL query endpoint using LangChain SQLDatabaseChain
- include chat router in FastAPI app and fix uvicorn module path
- update requirements with celery and redis

## Testing
- `pip install -r backend/requirements.txt`
- `python -m backend.app.main` *(started server)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688152877e38833390eed5a5b16c6482