### PR TITLE
Add user repository with migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ A .NET console application demonstrates SQLite data access using Dapper followin
    ```
 
 By default the app stores data in `app.db`, creating the database if it does not exist.
+The infrastructure project also exposes a `UserRepository` with async CRUD
+operations powered by Dapper. Migration scripts under
+`src/Infrastructure/Migrations` set up tables for `users`, `entries`, `tasks`
+and `llm_logs`. A simple `user_stats` view provides aggregate counts which the
+repository surfaces via `GetStatsAsync`.
 
 ## Dev Container
 

--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -15,17 +15,28 @@ var services = new ServiceCollection();
 var connectionString = configuration.GetConnectionString("Default") ?? "Data Source=app.db";
 services.AddSingleton(new SqliteConnectionFactory(connectionString));
 services.AddScoped<ITodoRepository, TodoRepository>();
+services.AddScoped<IUserRepository, UserRepository>();
 
 var provider = services.BuildServiceProvider();
 
-var repo = provider.GetRequiredService<ITodoRepository>();
-await repo.InitializeAsync();
+var todoRepo = provider.GetRequiredService<ITodoRepository>();
+await todoRepo.InitializeAsync();
 
-var id = await repo.AddAsync(new TodoItem { Title = "Learn Dapper", IsCompleted = false });
-Console.WriteLine($"Inserted Todo with Id {id}");
+var todoId = await todoRepo.AddAsync(new TodoItem { Title = "Learn Dapper", IsCompleted = false });
+Console.WriteLine($"Inserted Todo with Id {todoId}");
 
-var items = await repo.GetAllAsync();
+var items = await todoRepo.GetAllAsync();
 foreach (var item in items)
 {
     Console.WriteLine($"{item.Id}: {item.Title} - {(item.IsCompleted ? "Done" : "Pending")}");
+}
+
+var userRepo = provider.GetRequiredService<IUserRepository>();
+await userRepo.InitializeAsync();
+var userId = await userRepo.AddAsync(new User { Username = "alice", Email = "alice@example.com", CreatedAt = DateTime.UtcNow });
+Console.WriteLine($"Inserted User with Id {userId}");
+var stats = await userRepo.GetStatsAsync(userId);
+if (stats != null)
+{
+    Console.WriteLine($"Stats for {stats.Username}: Entries={stats.EntryCount}, Tasks={stats.TaskCount}");
 }

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -1,0 +1,9 @@
+namespace Domain.Entities;
+
+public class User
+{
+    public int Id { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/Domain/Interfaces/IUserRepository.cs
+++ b/src/Domain/Interfaces/IUserRepository.cs
@@ -1,0 +1,22 @@
+using Domain.Entities;
+
+namespace Domain.Interfaces;
+
+public interface IUserRepository
+{
+    Task InitializeAsync();
+    Task<int> AddAsync(User user);
+    Task<User?> GetByIdAsync(int id);
+    Task<IEnumerable<User>> GetAllAsync();
+    Task UpdateAsync(User user);
+    Task DeleteAsync(int id);
+    Task<UserStats?> GetStatsAsync(int userId);
+}
+
+public class UserStats
+{
+    public int UserId { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public int EntryCount { get; set; }
+    public int TaskCount { get; set; }
+}

--- a/src/Infrastructure/Migrations/0001_initial.sql
+++ b/src/Infrastructure/Migrations/0001_initial.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL UNIQUE,
+    email TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(user_id) REFERENCES users(id)
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    is_done INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(user_id) REFERENCES users(id)
+);
+
+CREATE TABLE IF NOT EXISTS llm_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    prompt TEXT NOT NULL,
+    response TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(user_id) REFERENCES users(id)
+);
+
+CREATE VIEW IF NOT EXISTS user_stats AS
+SELECT u.id AS UserId,
+       u.username AS Username,
+       COUNT(DISTINCT e.id) AS EntryCount,
+       COUNT(DISTINCT t.id) AS TaskCount
+FROM users u
+LEFT JOIN entries e ON e.user_id = u.id
+LEFT JOIN tasks t ON t.user_id = u.id
+GROUP BY u.id;

--- a/src/Infrastructure/Migrations/0002_add_details.sql
+++ b/src/Infrastructure/Migrations/0002_add_details.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tasks ADD COLUMN description TEXT;
+ALTER TABLE llm_logs ADD COLUMN model TEXT;

--- a/src/Infrastructure/Repositories/UserRepository.cs
+++ b/src/Infrastructure/Repositories/UserRepository.cs
@@ -1,0 +1,104 @@
+using Dapper;
+using Domain.Entities;
+using Domain.Interfaces;
+using Infrastructure.Data;
+
+namespace Infrastructure.Repositories;
+
+public class UserRepository : IUserRepository
+{
+    private readonly SqliteConnectionFactory _connectionFactory;
+
+    public UserRepository(SqliteConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        var sql = @"
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT NOT NULL UNIQUE,
+            email TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            content TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        );
+        CREATE TABLE IF NOT EXISTS tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            is_done INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        );
+        CREATE TABLE IF NOT EXISTS llm_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            prompt TEXT NOT NULL,
+            response TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        );
+        CREATE VIEW IF NOT EXISTS user_stats AS
+            SELECT u.id AS UserId, u.username AS Username,
+                COUNT(DISTINCT e.id) AS EntryCount,
+                COUNT(DISTINCT t.id) AS TaskCount
+            FROM users u
+                LEFT JOIN entries e ON e.user_id = u.id
+                LEFT JOIN tasks t ON t.user_id = u.id
+            GROUP BY u.id;
+        ";
+        await connection.ExecuteAsync(sql);
+    }
+
+    public async Task<int> AddAsync(User user)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        var sql = "INSERT INTO users (username, email, created_at) VALUES (@Username, @Email, @CreatedAt); SELECT last_insert_rowid();";
+        var id = await connection.ExecuteScalarAsync<long>(sql, user);
+        return (int)id;
+    }
+
+    public async Task<User?> GetByIdAsync(int id)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        var sql = "SELECT id as Id, username as Username, email as Email, created_at as CreatedAt FROM users WHERE id = @Id";
+        return await connection.QuerySingleOrDefaultAsync<User>(sql, new { Id = id });
+    }
+
+    public async Task<IEnumerable<User>> GetAllAsync()
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        var sql = "SELECT id as Id, username as Username, email as Email, created_at as CreatedAt FROM users";
+        return await connection.QueryAsync<User>(sql);
+    }
+
+    public async Task UpdateAsync(User user)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        var sql = "UPDATE users SET username = @Username, email = @Email WHERE id = @Id";
+        await connection.ExecuteAsync(sql, user);
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        var sql = "DELETE FROM users WHERE id = @Id";
+        await connection.ExecuteAsync(sql, new { Id = id });
+    }
+
+    public async Task<UserStats?> GetStatsAsync(int userId)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        var sql = "SELECT UserId, Username, EntryCount, TaskCount FROM user_stats WHERE UserId = @UserId";
+        return await connection.QuerySingleOrDefaultAsync<UserStats>(sql, new { UserId = userId });
+    }
+}


### PR DESCRIPTION
## Summary
- implement `UserRepository` with async CRUD operations and stats query
- define user entity and repository interface
- add SQLite migration scripts for initial schema and evolution
- extend console app to demonstrate user access and expose stats
- document new repository and migrations in README

## Testing
- `dotnet build src/ConsoleAppSolution.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6881586e1bc0833388ab5bbd34388c85