### PR TITLE
Add query builder and logging data layer

### DIFF
--- a/src/Domain/Entities/Entry.cs
+++ b/src/Domain/Entities/Entry.cs
@@ -1,0 +1,10 @@
+namespace Domain.Entities;
+
+public class Entry
+{
+    public int Id { get; set; }
+    public int UserId { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public string Tags { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/Domain/Interfaces/IEntryRepository.cs
+++ b/src/Domain/Interfaces/IEntryRepository.cs
@@ -1,0 +1,18 @@
+using Domain.Entities;
+
+namespace Domain.Interfaces;
+
+public class EntryQueryOptions
+{
+    public IEnumerable<string>? Tags { get; set; }
+    public DateTime? From { get; set; }
+    public DateTime? To { get; set; }
+    public string? Text { get; set; }
+}
+
+public interface IEntryRepository
+{
+    Task InitializeAsync();
+    Task<int> AddAsync(Entry entry);
+    Task<IEnumerable<Entry>> QueryAsync(EntryQueryOptions options);
+}

--- a/src/Infrastructure/Data/LoggingDataAccess.cs
+++ b/src/Infrastructure/Data/LoggingDataAccess.cs
@@ -1,0 +1,78 @@
+using System.Data;
+using System.Diagnostics;
+using Dapper;
+
+namespace Infrastructure.Data;
+
+public class LoggingDataAccess
+{
+    private readonly SqliteConnectionFactory _factory;
+
+    public LoggingDataAccess(SqliteConnectionFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using var connection = _factory.CreateConnection();
+        var sql = @"CREATE TABLE IF NOT EXISTS query_audit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            query TEXT NOT NULL,
+            duration_ms INTEGER NOT NULL,
+            executed_at TEXT NOT NULL
+        );";
+        await connection.ExecuteAsync(sql);
+    }
+
+    private async Task LogAsync(IDbConnection connection, string query, long durationMs)
+    {
+        var sql = "INSERT INTO query_audit (query, duration_ms, executed_at) VALUES (@Query, @Duration, @ExecutedAt)";
+        await connection.ExecuteAsync(sql, new
+        {
+            Query = query,
+            Duration = durationMs,
+            ExecutedAt = DateTime.UtcNow
+        });
+    }
+
+    public async Task<int> ExecuteAsync(string sql, object? param = null)
+    {
+        using var connection = _factory.CreateConnection();
+        var sw = Stopwatch.StartNew();
+        var result = await connection.ExecuteAsync(sql, param);
+        sw.Stop();
+        await LogAsync(connection, sql, sw.ElapsedMilliseconds);
+        return result;
+    }
+
+    public async Task<T> ExecuteScalarAsync<T>(string sql, object? param = null)
+    {
+        using var connection = _factory.CreateConnection();
+        var sw = Stopwatch.StartNew();
+        var result = await connection.ExecuteScalarAsync<T>(sql, param);
+        sw.Stop();
+        await LogAsync(connection, sql, sw.ElapsedMilliseconds);
+        return result;
+    }
+
+    public async Task<IEnumerable<T>> QueryAsync<T>(string sql, object? param = null)
+    {
+        using var connection = _factory.CreateConnection();
+        var sw = Stopwatch.StartNew();
+        var result = await connection.QueryAsync<T>(sql, param);
+        sw.Stop();
+        await LogAsync(connection, sql, sw.ElapsedMilliseconds);
+        return result;
+    }
+
+    public async Task<T?> QuerySingleOrDefaultAsync<T>(string sql, object? param = null)
+    {
+        using var connection = _factory.CreateConnection();
+        var sw = Stopwatch.StartNew();
+        var result = await connection.QuerySingleOrDefaultAsync<T>(sql, param);
+        sw.Stop();
+        await LogAsync(connection, sql, sw.ElapsedMilliseconds);
+        return result;
+    }
+}

--- a/src/Infrastructure/Migrations/0003_add_tags_and_audit.sql
+++ b/src/Infrastructure/Migrations/0003_add_tags_and_audit.sql
@@ -1,0 +1,8 @@
+ALTER TABLE entries ADD COLUMN tags TEXT;
+
+CREATE TABLE IF NOT EXISTS query_audit (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    query TEXT NOT NULL,
+    duration_ms INTEGER NOT NULL,
+    executed_at TEXT NOT NULL
+);

--- a/src/Infrastructure/QueryBuilders/EntryQueryBuilder.cs
+++ b/src/Infrastructure/QueryBuilders/EntryQueryBuilder.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using Dapper;
+using Domain.Interfaces;
+
+namespace Infrastructure.QueryBuilders;
+
+public class EntryQueryBuilder
+{
+    private readonly EntryQueryOptions _options;
+
+    public EntryQueryBuilder(EntryQueryOptions options)
+    {
+        _options = options;
+    }
+
+    public (string Sql, DynamicParameters Parameters) Build()
+    {
+        var sb = new StringBuilder("SELECT id as Id, user_id as UserId, content as Content, tags as Tags, created_at as CreatedAt FROM entries");
+        var conditions = new List<string>();
+        var parameters = new DynamicParameters();
+        if (_options.Tags != null && _options.Tags.Any())
+        {
+            int idx = 0;
+            foreach (var tag in _options.Tags)
+            {
+                var name = $"tag{idx}";
+                conditions.Add($"tags LIKE @{name}");
+                parameters.Add(name, $"%{tag}%");
+                idx++;
+            }
+        }
+        if (_options.From.HasValue)
+        {
+            conditions.Add("created_at >= @from");
+            parameters.Add("from", _options.From.Value);
+        }
+        if (_options.To.HasValue)
+        {
+            conditions.Add("created_at <= @to");
+            parameters.Add("to", _options.To.Value);
+        }
+        if (!string.IsNullOrEmpty(_options.Text))
+        {
+            conditions.Add("content LIKE @text");
+            parameters.Add("text", $"%{_options.Text}%");
+        }
+
+        if (conditions.Count > 0)
+        {
+            sb.Append(" WHERE ").Append(string.Join(" AND ", conditions));
+        }
+
+        return (sb.ToString(), parameters);
+    }
+}

--- a/src/Infrastructure/Repositories/EntryRepository.cs
+++ b/src/Infrastructure/Repositories/EntryRepository.cs
@@ -1,0 +1,44 @@
+using Dapper;
+using Domain.Entities;
+using Domain.Interfaces;
+using Infrastructure.Data;
+using Infrastructure.QueryBuilders;
+
+namespace Infrastructure.Repositories;
+
+public class EntryRepository : IEntryRepository
+{
+    private readonly LoggingDataAccess _db;
+
+    public EntryRepository(LoggingDataAccess db)
+    {
+        _db = db;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var sql = @"CREATE TABLE IF NOT EXISTS entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            content TEXT NOT NULL,
+            tags TEXT,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        );";
+        await _db.ExecuteAsync(sql);
+    }
+
+    public async Task<int> AddAsync(Entry entry)
+    {
+        var sql = "INSERT INTO entries (user_id, content, tags, created_at) VALUES (@UserId, @Content, @Tags, @CreatedAt); SELECT last_insert_rowid();";
+        var id = await _db.ExecuteScalarAsync<long>(sql, entry);
+        return (int)id;
+    }
+
+    public async Task<IEnumerable<Entry>> QueryAsync(EntryQueryOptions options)
+    {
+        var builder = new EntryQueryBuilder(options);
+        var (sql, parameters) = builder.Build();
+        return await _db.QueryAsync<Entry>(sql, parameters);
+    }
+}

--- a/src/Infrastructure/Repositories/TodoRepository.cs
+++ b/src/Infrastructure/Repositories/TodoRepository.cs
@@ -1,4 +1,3 @@
-using Dapper;
 using Domain.Entities;
 using Domain.Interfaces;
 using Infrastructure.Data;
@@ -7,36 +6,33 @@ namespace Infrastructure.Repositories;
 
 public class TodoRepository : ITodoRepository
 {
-    private readonly SqliteConnectionFactory _connectionFactory;
+    private readonly LoggingDataAccess _db;
 
-    public TodoRepository(SqliteConnectionFactory connectionFactory)
+    public TodoRepository(LoggingDataAccess db)
     {
-        _connectionFactory = connectionFactory;
+        _db = db;
     }
 
     public async Task InitializeAsync()
     {
-        using var connection = _connectionFactory.CreateConnection();
         var query = @"CREATE TABLE IF NOT EXISTS Todos (
             Id INTEGER PRIMARY KEY AUTOINCREMENT,
             Title TEXT NOT NULL,
             IsCompleted INTEGER NOT NULL
         );";
-        await connection.ExecuteAsync(query);
+        await _db.ExecuteAsync(query);
     }
 
     public async Task<int> AddAsync(TodoItem item)
     {
-        using var connection = _connectionFactory.CreateConnection();
         var sql = "INSERT INTO Todos (Title, IsCompleted) VALUES (@Title, @IsCompleted); SELECT last_insert_rowid();";
-        var id = await connection.ExecuteScalarAsync<long>(sql, item);
+        var id = await _db.ExecuteScalarAsync<long>(sql, item);
         return (int)id;
     }
 
     public async Task<IEnumerable<TodoItem>> GetAllAsync()
     {
-        using var connection = _connectionFactory.CreateConnection();
         var sql = "SELECT Id, Title, IsCompleted FROM Todos";
-        return await connection.QueryAsync<TodoItem>(sql);
+        return await _db.QueryAsync<TodoItem>(sql);
     }
 }

--- a/src/Infrastructure/Repositories/UserRepository.cs
+++ b/src/Infrastructure/Repositories/UserRepository.cs
@@ -1,35 +1,27 @@
-using Dapper;
 using Domain.Entities;
 using Domain.Interfaces;
 using Infrastructure.Data;
+using Dapper;
 
 namespace Infrastructure.Repositories;
 
 public class UserRepository : IUserRepository
 {
-    private readonly SqliteConnectionFactory _connectionFactory;
+    private readonly LoggingDataAccess _db;
 
-    public UserRepository(SqliteConnectionFactory connectionFactory)
+    public UserRepository(LoggingDataAccess db)
     {
-        _connectionFactory = connectionFactory;
+        _db = db;
     }
 
     public async Task InitializeAsync()
     {
-        using var connection = _connectionFactory.CreateConnection();
         var sql = @"
         CREATE TABLE IF NOT EXISTS users (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             username TEXT NOT NULL UNIQUE,
             email TEXT NOT NULL,
             created_at TEXT NOT NULL
-        );
-        CREATE TABLE IF NOT EXISTS entries (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER NOT NULL,
-            content TEXT NOT NULL,
-            created_at TEXT NOT NULL,
-            FOREIGN KEY(user_id) REFERENCES users(id)
         );
         CREATE TABLE IF NOT EXISTS tasks (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -44,6 +36,7 @@ public class UserRepository : IUserRepository
             user_id INTEGER NOT NULL,
             prompt TEXT NOT NULL,
             response TEXT NOT NULL,
+            model TEXT,
             created_at TEXT NOT NULL,
             FOREIGN KEY(user_id) REFERENCES users(id)
         );
@@ -54,51 +47,44 @@ public class UserRepository : IUserRepository
             FROM users u
                 LEFT JOIN entries e ON e.user_id = u.id
                 LEFT JOIN tasks t ON t.user_id = u.id
-            GROUP BY u.id;
-        ";
-        await connection.ExecuteAsync(sql);
+            GROUP BY u.id;";
+        await _db.ExecuteAsync(sql);
     }
 
     public async Task<int> AddAsync(User user)
     {
-        using var connection = _connectionFactory.CreateConnection();
         var sql = "INSERT INTO users (username, email, created_at) VALUES (@Username, @Email, @CreatedAt); SELECT last_insert_rowid();";
-        var id = await connection.ExecuteScalarAsync<long>(sql, user);
+        var id = await _db.ExecuteScalarAsync<long>(sql, user);
         return (int)id;
     }
 
     public async Task<User?> GetByIdAsync(int id)
     {
-        using var connection = _connectionFactory.CreateConnection();
         var sql = "SELECT id as Id, username as Username, email as Email, created_at as CreatedAt FROM users WHERE id = @Id";
-        return await connection.QuerySingleOrDefaultAsync<User>(sql, new { Id = id });
+        return await _db.QuerySingleOrDefaultAsync<User>(sql, new { Id = id });
     }
 
     public async Task<IEnumerable<User>> GetAllAsync()
     {
-        using var connection = _connectionFactory.CreateConnection();
         var sql = "SELECT id as Id, username as Username, email as Email, created_at as CreatedAt FROM users";
-        return await connection.QueryAsync<User>(sql);
+        return await _db.QueryAsync<User>(sql);
     }
 
     public async Task UpdateAsync(User user)
     {
-        using var connection = _connectionFactory.CreateConnection();
         var sql = "UPDATE users SET username = @Username, email = @Email WHERE id = @Id";
-        await connection.ExecuteAsync(sql, user);
+        await _db.ExecuteAsync(sql, user);
     }
 
     public async Task DeleteAsync(int id)
     {
-        using var connection = _connectionFactory.CreateConnection();
         var sql = "DELETE FROM users WHERE id = @Id";
-        await connection.ExecuteAsync(sql, new { Id = id });
+        await _db.ExecuteAsync(sql, new { Id = id });
     }
 
     public async Task<UserStats?> GetStatsAsync(int userId)
     {
-        using var connection = _connectionFactory.CreateConnection();
         var sql = "SELECT UserId, Username, EntryCount, TaskCount FROM user_stats WHERE UserId = @UserId";
-        return await connection.QuerySingleOrDefaultAsync<UserStats>(sql, new { UserId = userId });
+        return await _db.QuerySingleOrDefaultAsync<UserStats>(sql, new { UserId = userId });
     }
 }


### PR DESCRIPTION
## Summary
- implement a logging data-access service that writes executed SQL and duration to `query_audit`
- create entry filtering with `EntryRepository` and `EntryQueryBuilder`
- register the new services in the console app and demo a simple query
- add migration to add `tags` column to entries and create the audit table

## Testing
- `dotnet build src/ConsoleAppSolution.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688159c36d3c83338fd6fd8fc97a6ab6