### PR TITLE
Refactor chat and tasks

### DIFF
--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -1,0 +1,19 @@
+from typing import Protocol
+
+class LLMClient(Protocol):
+    """Interface for language model clients."""
+
+    def invoke(self, prompt: str) -> str:
+        ...
+
+
+class OllamaLLM:
+    """Ollama-based implementation of :class:`LLMClient`."""
+
+    def __init__(self, model: str = "llama3"):
+        from langchain_community.llms import Ollama
+
+        self._client = Ollama(model=model)
+
+    def invoke(self, prompt: str) -> str:  # pragma: no cover - runtime call
+        return self._client.invoke(prompt)

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -1,34 +1,37 @@
 from pathlib import Path
-import json
+from fastapi import APIRouter, HTTPException, Body, Depends
 
-from fastapi import APIRouter, HTTPException, Body
-from langchain_community.llms import Ollama
+from ..llm import LLMClient, OllamaLLM
+from ..utils.cache import Cache
 
 router = APIRouter(tags=["chat"], prefix="/chat")
 
 CACHE_FILE = Path(__file__).resolve().parents[1] / "data" / "chat_cache.json"
-CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-
-if CACHE_FILE.exists():
-    CACHE = json.loads(CACHE_FILE.read_text())
-else:
-    CACHE = {}
-
-llm = Ollama(model="llama3")
 
 
-def _save_cache() -> None:
-    CACHE_FILE.write_text(json.dumps(CACHE))
+class ChatService:
+    def __init__(self, llm: LLMClient, cache: Cache):
+        self._llm = llm
+        self._cache = cache
+
+    def chat(self, message: str) -> dict:
+        cached = self._cache.get(message)
+        if cached is not None:
+            return {"response": cached, "cached": True}
+        try:
+            response = self._llm.invoke(message)
+        except Exception as exc:  # pragma: no cover - runtime failure
+            raise HTTPException(status_code=500, detail=str(exc))
+        self._cache.set(message, response)
+        return {"response": response, "cached": False}
+
+
+def get_service() -> ChatService:
+    llm = OllamaLLM()
+    cache = Cache(CACHE_FILE)
+    return ChatService(llm, cache)
 
 
 @router.post("/")
-def chat(message: str = Body(..., embed=True)):
-    if message in CACHE:
-        return {"response": CACHE[message], "cached": True}
-    try:
-        response = llm.invoke(message)
-    except Exception as exc:  # pragma: no cover - runtime failure
-        raise HTTPException(status_code=500, detail=str(exc))
-    CACHE[message] = response
-    _save_cache()
-    return {"response": response, "cached": False}
+def chat(message: str = Body(..., embed=True), service: ChatService = Depends(get_service)):
+    return service.chat(message)

--- a/backend/app/services/summarization_service.py
+++ b/backend/app/services/summarization_service.py
@@ -1,0 +1,15 @@
+from sqlalchemy.orm import Session
+
+from ..llm import LLMClient
+from ..models import Entry
+
+class SummarizationService:
+    def __init__(self, llm: LLMClient):
+        self._llm = llm
+
+    def summarize_pending_entries(self, db: Session) -> None:
+        entries = db.query(Entry).filter(Entry.summarized == False).all()
+        for entry in entries:
+            summary = self._llm.invoke(f"Summarize the following text:\n{entry.content}")
+            entry.summary = summary.strip()
+            entry.summarized = True

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,9 +1,9 @@
 from celery import Celery
-from langchain_community.llms import Ollama
 
 from .config import Settings
 from .db import SessionLocal
-from .models import Entry
+from .llm import OllamaLLM
+from .services.summarization_service import SummarizationService
 
 settings = Settings()
 
@@ -16,16 +16,14 @@ celery_app.conf.beat_schedule = {
 }
 
 
+summarization_service = SummarizationService(OllamaLLM())
+
+
 @celery_app.task
 def summarize_entries():
     db = SessionLocal()
     try:
-        llm = Ollama(model="llama3")
-        entries = db.query(Entry).filter(Entry.summarized == False).all()
-        for entry in entries:
-            summary = llm.invoke(f"Summarize the following text:\n{entry.content}")
-            entry.summary = summary.strip()
-            entry.summarized = True
+        summarization_service.summarize_pending_entries(db)
         db.commit()
     finally:
         db.close()

--- a/backend/app/utils/cache.py
+++ b/backend/app/utils/cache.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import json
+from typing import Dict, Optional
+
+class Cache:
+    """Simple file-backed cache."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._data: Dict[str, str] = {}
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.exists():
+            try:
+                self._data = json.loads(self.path.read_text())
+            except json.JSONDecodeError:
+                self._data = {}
+
+    def get(self, key: str) -> Optional[str]:
+        return self._data.get(key)
+
+    def set(self, key: str, value: str) -> None:
+        self._data[key] = value
+        self.path.write_text(json.dumps(self._data))


### PR DESCRIPTION
## Summary
- introduce `LLMClient` interface and `OllamaLLM` implementation
- add a simple file-backed `Cache`
- refactor chat endpoint into a `ChatService` class
- add `SummarizationService` and update Celery tasks to use it

## Testing
- `python -m py_compile backend/app/llm.py backend/app/utils/cache.py backend/app/services/chat_service.py backend/app/services/summarization_service.py backend/app/tasks.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882970d11ec8333af3eaf2ac5e16a4a