### PR TITLE
Add run_logged script with log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ bin/
 obj/
 *.db
 
+
+# Logs
+run.log

--- a/run_logged.sh
+++ b/run_logged.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Run the full solution quietly while logging progress to run.log
+set -e
+
+LOG_FILE="run.log"
+# overwrite the log file each run
+: > "$LOG_FILE"
+
+# redirect all output to the log file
+exec >>"$LOG_FILE" 2>&1
+
+echo "=== Run started at $(date) ==="
+
+# Build and run .NET console application
+echo "[DOTNET BUILD]"
+dotnet build src/ConsoleAppSolution.sln -c Release
+
+echo "[DOTNET RUN]"
+dotnet run --project src/ConsoleApp/ConsoleApp.csproj &
+DOTNET_PID=$!
+
+# Install Python backend dependencies
+echo "[PIP INSTALL]"
+pip install -r backend/requirements.txt
+
+# Launch FastAPI backend
+echo "[BACKEND RUN]"
+python -m backend.app.main &
+BACKEND_PID=$!
+
+# Serve Vue frontend
+echo "[FRONTEND SERVE]"
+cd vue
+python -m http.server &
+FRONTEND_PID=$!
+cd ..
+
+cleanup() {
+  echo "[CLEANUP]"
+  kill $DOTNET_PID $BACKEND_PID $FRONTEND_PID
+}
+trap cleanup EXIT
+
+wait


### PR DESCRIPTION
## Summary
- create `run_logged.sh` to download packages and run the solution quietly
- keep execution logs in `run.log` and ignore it with `.gitignore`

## Testing
- `bash -n run_logged.sh`
- `./run_logged.sh` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688298be76d08333bccb461fc3035cf3