### PR TITLE
Kill backend port before running

### DIFF
--- a/run_all.sh
+++ b/run_all.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
+# Ensure the backend port is free before starting
+free_port() {
+  local port=$1
+  if lsof -ti tcp:"$port" > /dev/null 2>&1; then
+    echo "Port $port in use - terminating process"
+    lsof -ti tcp:"$port" | xargs kill -9
+  fi
+}
+
+free_port 8000
+
 # Build and run the .NET console application
 
 dotnet build src/ConsoleAppSolution.sln -c Release

--- a/run_logged.sh
+++ b/run_logged.sh
@@ -2,6 +2,17 @@
 # Run the full solution quietly while logging progress to run.log
 set -e
 
+# Ensure the backend port is free before starting
+free_port() {
+  local port=$1
+  if lsof -ti tcp:"$port" > /dev/null 2>&1; then
+    echo "Port $port in use - terminating process"
+    lsof -ti tcp:"$port" | xargs kill -9
+  fi
+}
+
+free_port 8000
+
 LOG_FILE="run.log"
 # overwrite the log file each run
 : > "$LOG_FILE"


### PR DESCRIPTION
## Summary
- free TCP port 8000 prior to launching the FastAPI backend
- apply the same check in `run_logged.sh`

## Testing
- `npm install`
- `pip install -r backend/requirements.txt`
- `bash scripts/test_pipeline.sh` *(fails: `/migrations/0001_initial.sql` not found due to missing docker)*

------
https://chatgpt.com/codex/tasks/task_e_6883ddd694fc8333a219c5658b2c24c7