### PR TITLE
Add root check to run scripts

### DIFF
--- a/run_all.sh
+++ b/run_all.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+# Relaunch with sudo if not running as root
+if [[ $EUID -ne 0 ]]; then
+  echo "This script requires administrative privileges. Re-running with sudo..."
+  exec sudo "$0" "$@"
+fi
+
 # Ensure the backend port is free before starting
 free_port() {
   local port=$1

--- a/run_logged.sh
+++ b/run_logged.sh
@@ -2,6 +2,12 @@
 # Run the full solution quietly while logging progress to run.log
 set -e
 
+# Relaunch with sudo if not running as root
+if [[ $EUID -ne 0 ]]; then
+  echo "This script requires administrative privileges. Re-running with sudo..."
+  exec sudo "$0" "$@"
+fi
+
 # Ensure the backend port is free before starting
 free_port() {
   local port=$1


### PR DESCRIPTION
## Summary
- re-run run_all.sh and run_logged.sh with sudo when not run as root
- keep port cleanup logic as before

## Testing
- `bash scripts/test_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883f4c23f1883338173fd02c689cece