### PR TITLE
Add startup port check

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,27 @@
 import logging
+import socket
 from uvicorn import run
 from . import app, settings
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def port_in_use(port: int) -> bool:
+    """Return True if the given TCP port is in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        return sock.connect_ex(("localhost", port)) == 0
+
 if __name__ == "__main__":
-    logger.info("Starting %s", settings.app_name)
+    logger.info("Starting %s on port %s", settings.app_name, settings.port)
+
+    if port_in_use(settings.port):
+        logger.error(
+            "Port %s is already in use. Set PORT to another value or free the port and try again.",
+            settings.port,
+        )
+        raise SystemExit(1)
+
     run(
         "backend.app:app",
         host=settings.host,


### PR DESCRIPTION
## Summary
- ensure the FastAPI backend only starts when the configured port is free
- log a helpful error when the port is already in use

## Testing
- `npm install`
- `pip install -r backend/requirements.txt`
- `bash scripts/test_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883fa2458a08333b5f870938928fa66