### PR TITLE
Add port availability checks

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,35 @@
 import logging
+import socket
+import sys
+
 from uvicorn import run
 from . import app, settings
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def port_available(host: str, port: int) -> bool:
+    """Return True if the given host/port can be bound."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, port))
+        except OSError as exc:
+            logger.error("Cannot bind to %s:%s - %s", host, port, exc)
+            return False
+        logger.debug("Port %s on %s is free", port, host)
+        return True
+
 if __name__ == "__main__":
-    logger.info("Starting %s", settings.app_name)
+    logger.info("Starting %s on %s:%s", settings.app_name, settings.host, settings.port)
+    if not port_available(settings.host, settings.port):
+        logger.error(
+            "Port %s is busy. Run 'netstat -aon | findstr :%s' to find the process using it or set PORT to another value.",
+            settings.port,
+            settings.port,
+        )
+        sys.exit(1)
+
     run(
         "backend.app:app",
         host=settings.host,

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,20 @@
+import socket
+
+from ..app.main import port_available
+
+
+def test_port_available_free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        host, port = s.getsockname()
+    assert port_available(host, port)
+
+
+def test_port_available_busy_port():
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    host, port = sock.getsockname()
+    try:
+        assert not port_available(host, port)
+    finally:
+        sock.close()


### PR DESCRIPTION
## Summary
- warn if backend port cannot be bound before starting
- add unit tests for port availability helper
- improve port check message

## Testing
- `bash scripts/test_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883fa2458a08333b5f870938928fa66