### PR TITLE
Fix missing user_id column

### DIFF
--- a/src/Infrastructure/Repositories/EntryRepository.cs
+++ b/src/Infrastructure/Repositories/EntryRepository.cs
@@ -23,6 +23,18 @@ public class EntryRepository : BaseRepository<Entry>, IEntryRepository
             FOREIGN KEY(user_id) REFERENCES users(id)
         );";
         await _db.ExecuteAsync(sql);
+
+        // Handle databases created before the user_id column existed. In
+        // older revisions entries were stored without linking back to the
+        // user, so queries against the user_stats view would fail. Ensure the
+        // column is present before continuing.
+        var check = "SELECT COUNT(*) FROM pragma_table_info('entries') WHERE name = @Name";
+        if (await _db.ExecuteScalarAsync<long>(check, new { Name = "user_id" }) == 0)
+        {
+            // Add the column with a NULL default to avoid errors when existing
+            // rows are present. New inserts will supply a valid user id.
+            await _db.ExecuteAsync("ALTER TABLE entries ADD COLUMN user_id INTEGER;");
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- ensure the `entries` table contains a `user_id` column even on older databases

## Testing
- `scripts/test_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883fdd9b2608333bbc4d1efcf699055