### PR TITLE
Add generic schema guard and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Use `./run_logged.sh` if you want the same process to log output to `run.log`.
 
 2. In your browser open the served page. The client expects the FastAPI backend
    to be available at `http://localhost:8000/api`.
-   If another service is already using port 8000 you can change the backend
-   port by editing `backend/app/config.py` or setting the `PORT` environment
-   variable before starting the server.
+   When started the server tries to bind to port `8000` but if it is already
+   taken the process automatically increments the port until a free one is
+   found. Set the `PORT` environment variable to force a specific port or edit
+   `backend/app/config.py`.
 
 You can modify `vue/index.html` and `vue/app.js` to tweak the UI or add new
 components.

--- a/src/Infrastructure.Tests/SchemaMigrationTests.cs
+++ b/src/Infrastructure.Tests/SchemaMigrationTests.cs
@@ -11,7 +11,7 @@ public class SchemaMigrationTests
     [Fact]
     public async Task MigratesLegacySchema()
     {
-        var connString = "Data Source=mem.db;Mode=Memory;Cache=Shared";
+        var connString = "Data Source=mem_schema.db;Mode=Memory;Cache=Shared";
         using var keepAlive = new SqliteConnection(connString);
         keepAlive.Open();
 
@@ -22,8 +22,7 @@ public class SchemaMigrationTests
         );";
         var legacyEntries = @"CREATE TABLE entries (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            content TEXT NOT NULL,
-            created_at TEXT NOT NULL
+            content TEXT NOT NULL
         );";
         keepAlive.Execute(legacyUsers);
         keepAlive.Execute(legacyEntries);
@@ -46,5 +45,6 @@ public class SchemaMigrationTests
 
         Assert.Contains("email", userCols);
         Assert.Contains("tags", entryCols);
+        Assert.Contains("created_at", entryCols);
     }
 }

--- a/src/Infrastructure.Tests/UserRepositoryMigrationTests.cs
+++ b/src/Infrastructure.Tests/UserRepositoryMigrationTests.cs
@@ -13,7 +13,7 @@ public class UserRepositoryMigrationTests
     [Fact]
     public async Task AddsEmailColumnToLegacySchema()
     {
-        var connString = "Data Source=mem.db;Mode=Memory;Cache=Shared";
+        var connString = "Data Source=mem_users.db;Mode=Memory;Cache=Shared";
         using var keepAlive = new SqliteConnection(connString);
         keepAlive.Open();
 


### PR DESCRIPTION
## Summary
- add EnsureColumn migration helper and apply it for `entries.tags` and new `entries.created_at`
- suppress ExecuteScalarAsync nullability warning
- update migration tests for `entries.created_at`
- document dynamic port fallback logic

## Testing
- `dotnet build src/ConsoleAppSolution.sln -c Release`
- `dotnet test src/Infrastructure.Tests/Infrastructure.Tests.csproj -c Release --no-build --filter FullyQualifiedName~UserRepositoryMigrationTests`
- `dotnet test src/Infrastructure.Tests/Infrastructure.Tests.csproj -c Release --no-build --filter FullyQualifiedName~SchemaMigrationTests`

------
https://chatgpt.com/codex/tasks/task_e_6884797530bc8333bb24fd04c277bef8