### PR TITLE
Add Docker compose and ingestion stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: dev
+
+dev:
+@docker compose up --build -d
+@sleep 5
+@docker compose exec backend python -m backend.app.manage migrate
+@docker compose exec backend python -m backend.app.manage seed
+@python -m webbrowser http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Use `./run_logged.sh` if you want the same process to log output to `run.log`.
 You can modify `vue/index.html` and `vue/app.js` to tweak the UI or add new
 components.
 
+## Docker Compose Stack
+
+Run the full stack in one shot using Docker Compose and the provided Makefile:
+
+```bash
+make dev
+```
+
+This launches Postgres with pgvector, Redis, the FastAPI API plus Celery worker,
+an Ollama instance and the Vue front-end. The `dev` target runs database
+migrations, seeds a sample Markdown note and opens the UI in your browser.
+
 
 ## Backend API
 
@@ -71,6 +83,12 @@ curl "http://localhost:8000/api/trivia?q=What is the largest planet?"
 
 Make sure to install the new Python dependencies and have an Ollama model (for
 example `llama3`) available.
+
+### Retrieval QA
+
+The `/api/qa/stream` endpoint streams answers from a LangChain RetrievalQA chain
+backed by pgvector. Results include markdown formatted citations linking to the
+original note.
 
 
 ## Console Service
@@ -139,6 +157,15 @@ Background tasks that summarize entries can be started separately using
 ```bash
 celery -A backend.app.tasks worker --beat
 ```
+The worker also schedules a nightly digest summarizing new chunks and maintains
+wiki-style backlinks between notes.
+
+### Importing Data
+
+Upload a ZIP archive to `/api/import` containing Markdown or PDF files. The
+server extracts each document, splits it by headings, de-duplicates chunks and
+queues embedding jobs in Celery. Vectors are stored in Postgres using the
+pgvector extension.
 
 
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -10,6 +10,8 @@ from .services.user_service import router as user_router
 from .services.agent_service import router as agent_router
 from .services.chat_service import router as chat_router
 from .services.entry_service import router as entry_router
+from .services.import_service import router as import_router
+from .services.qa_service import router as qa_router
 
 
 settings = Settings()
@@ -33,4 +35,6 @@ app.include_router(user_router, prefix="/api")
 app.include_router(agent_router, prefix="/api")
 app.include_router(chat_router, prefix="/api")
 app.include_router(entry_router, prefix="/api")
+app.include_router(import_router, prefix="/api")
+app.include_router(qa_router, prefix="/api")
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,6 +7,10 @@ class Settings(BaseSettings):
     debug: bool = False
     allowed_origins: list[str] = ["*"]
     redis_url: str = "redis://localhost:6379/0"
+    database_url: str = "sqlite:///./app.db"
+    model: str = "llama3"
+    retrieval_k: int = 8
+    chunk_size: int = 512
 
     class Config:
         env_file = ".env"

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,10 +1,14 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./app.db"
+# Use Postgres when DATABASE_URL provided, fallback to local SQLite
+SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+connect_args = {"check_same_thread": False} if SQLALCHEMY_DATABASE_URL.startswith("sqlite") else {}
 
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    SQLALCHEMY_DATABASE_URL, connect_args=connect_args
 )
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 

--- a/backend/app/manage.py
+++ b/backend/app/manage.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from .config import Settings
+from . import models
+from .db import Base
+
+settings = Settings()
+engine = create_engine(settings.database_url)
+Session = sessionmaker(bind=engine)
+
+SAMPLE_MD = Path(__file__).resolve().parents[1] / 'data' / 'sample.md'
+
+def migrate():
+    Base.metadata.create_all(bind=engine)
+
+
+def seed():
+    if not SAMPLE_MD.exists():
+        return
+    session = Session()
+    with SAMPLE_MD.open() as f:
+        text = f.read()
+    entry = models.Entry(content=text)
+    session.add(entry)
+    session.commit()
+    session.close()
+
+if __name__ == '__main__':
+    import sys
+    cmd = sys.argv[1] if len(sys.argv) > 1 else 'migrate'
+    if cmd == 'migrate':
+        migrate()
+    elif cmd == 'seed':
+        seed()

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -1,0 +1,72 @@
+from fastapi import APIRouter, UploadFile, File as UploadFileType, Depends
+from sqlalchemy.orm import Session
+from zipfile import ZipFile
+from pathlib import Path
+import hashlib
+import tempfile
+
+from .. import models, dependencies, tasks
+
+router = APIRouter(tags=["import"])
+UPLOAD_ROOT = Path("uploads")
+UPLOAD_ROOT.mkdir(exist_ok=True)
+
+
+def extract_text(path: Path) -> str:
+    if path.suffix.lower() == ".pdf":
+        from PyPDF2 import PdfReader
+        reader = PdfReader(str(path))
+        return "\n".join(page.extract_text() or "" for page in reader.pages)
+    return path.read_text(encoding="utf-8")
+
+
+def split_by_heading(text: str):
+    lines = text.splitlines()
+    chunks = []
+    start = 0
+    current = []
+    for idx, line in enumerate(lines, 1):
+        if line.startswith("#") and current:
+            chunks.append(("\n".join(current), start, idx-1))
+            current = []
+            start = idx
+        current.append(line)
+    if current:
+        chunks.append(("\n".join(current), start, len(lines)))
+    return chunks
+
+
+def get_db(dep=Depends(dependencies.get_db)):
+    yield from dep
+
+
+@router.post("/import")
+async def import_zip(file: UploadFile = UploadFileType(...), db: Session = Depends(get_db)):
+    data = await file.read()
+    tmp_dir = Path(tempfile.mkdtemp())
+    zip_path = tmp_dir / "upload.zip"
+    zip_path.write_bytes(data)
+    with ZipFile(zip_path) as zf:
+        zf.extractall(tmp_dir)
+    for path in tmp_dir.rglob("*"):
+        if path.suffix.lower() not in {".md", ".pdf"}:
+            continue
+        text = extract_text(path)
+        db_file = db.query(models.File).filter_by(path=str(path.name)).first()
+        if not db_file:
+            db_file = models.File(path=str(path.name), name=path.name)
+            db.add(db_file)
+            db.commit()
+            db.refresh(db_file)
+        for chunk_text, start, end in split_by_heading(text):
+            h = hashlib.sha256(chunk_text.encode()).hexdigest()
+            exists = db.query(models.Chunk).filter_by(content_hash=h).first()
+            if exists:
+                continue
+            chunk = models.Chunk(file_id=db_file.id, content=chunk_text, content_hash=h,
+                                 start_line=start, end_line=end)
+            db.add(chunk)
+            db.commit()
+            db.refresh(chunk)
+            tasks.embed_chunk.delay(chunk.id)
+    return {"status": "ok"}

--- a/backend/app/services/qa_service.py
+++ b/backend/app/services/qa_service.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, Body
+from sse_starlette.sse import EventSourceResponse
+from langchain_community.vectorstores import PGVector
+from langchain_community.embeddings import OllamaEmbeddings
+from langchain.chains import RetrievalQA
+from langchain.prompts import PromptTemplate
+from langchain.callbacks.streaming_aiter import AsyncIteratorCallbackHandler
+from langchain_community.llms import Ollama
+import asyncio
+
+from ..config import Settings
+
+router = APIRouter(tags=["qa"], prefix="/qa")
+settings = Settings()
+
+
+def _chain():
+    embeddings = OllamaEmbeddings(model="nomic-embed-text")
+    vs = PGVector(
+        connection_string=settings.database_url,
+        embedding_function=embeddings,
+        collection_name="embeddings",
+    )
+    retriever = vs.as_retriever(search_kwargs={"k": settings.retrieval_k})
+    template = (
+        "Answer using the context. Append markdown citations linking back to "
+        "{source_path}#{line}.\n{question}"
+    )
+    prompt = PromptTemplate.from_template(template)
+    llm = Ollama(model=settings.model, streaming=True)
+    return RetrievalQA.from_chain_type(
+        llm=llm,
+        retriever=retriever,
+        return_source_documents=True,
+        chain_type_kwargs={"prompt": prompt},
+    )
+
+
+@router.post("/stream")
+async def qa_stream(question: str = Body(..., embed=True)):
+    chain = _chain()
+    handler = AsyncIteratorCallbackHandler()
+    task = asyncio.create_task(chain.acall(question, callbacks=[handler]))
+
+    async def event_generator():
+        async for token in handler.aiter():
+            yield {"event": "token", "data": token}
+        await task
+        yield {"event": "end", "data": ""}
+
+    return EventSourceResponse(event_generator())

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,9 +1,13 @@
 from celery import Celery
+from celery.schedules import crontab
+import datetime
 
 from .config import Settings
 from .db import SessionLocal
 from .llm import OllamaLLM
 from .services.summarization_service import SummarizationService
+from . import models
+from langchain_community.embeddings import OllamaEmbeddings
 
 settings = Settings()
 
@@ -12,7 +16,11 @@ celery_app.conf.beat_schedule = {
     "summarize-entries": {
         "task": "app.tasks.summarize_entries",
         "schedule": 60.0,
-    }
+    },
+    "daily-digest": {
+        "task": "app.tasks.daily_digest",
+        "schedule": crontab(hour=0, minute=0),
+    },
 }
 
 
@@ -27,3 +35,52 @@ def summarize_entries():
         db.commit()
     finally:
         db.close()
+
+
+@celery_app.task
+def embed_chunk(chunk_id: int):
+    db = SessionLocal()
+    try:
+        chunk = db.query(models.Chunk).get(chunk_id)
+        if chunk is None:
+            return
+        embeddings = OllamaEmbeddings(model="nomic-embed-text")
+        vector = embeddings.embed_query(chunk.content)
+        emb = models.Embedding(chunk_id=chunk.id, vector=vector)
+        db.add(emb)
+        db.commit()
+    finally:
+        db.close()
+
+
+def _extract_links(text: str) -> list[str]:
+    import re
+    return re.findall(r"\[\[(.+?)\]\]", text)
+
+
+@celery_app.task
+def daily_digest():
+    db = SessionLocal()
+    try:
+        since = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        chunks = db.query(models.Chunk).filter(models.Chunk.updated_at >= since).all()
+        if not chunks:
+            return
+        combined = "\n".join(c.content for c in chunks)
+        summary = summarization_service.llm_invoke(f"Summarize in <=200 words:\n{combined}")
+        tokens = len(summary.split())
+        db.add(models.DailySummary(summary=summary.strip(), token_count=tokens))
+        db.commit()
+        _update_backlinks(db, chunks)
+    finally:
+        db.close()
+
+
+def _update_backlinks(db, chunks):
+    for chunk in chunks:
+        links = _extract_links(chunk.content)
+        for title in links:
+            target = db.query(models.Chunk).filter(models.Chunk.content.like(f"%# {title}%")).first()
+            if target:
+                db.add(models.Backlink(source_id=chunk.id, target_id=target.id))
+    db.commit()

--- a/backend/data/sample.md
+++ b/backend/data/sample.md
@@ -1,0 +1,3 @@
+# Sample
+
+This is a sample note used to seed the database.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,8 @@ langchain-experimental
 celery
 redis
 pytest-benchmark
+psycopg2-binary
+pgvector
+sse-starlette
+PyPDF2
+python-multipart

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+services:
+  db:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: app
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+  backend:
+    build: ./backend
+    command: uvicorn backend.app:app --host 0.0.0.0 --port 8000
+    environment:
+      DATABASE_URL: postgresql+psycopg2://app:app@db:5432/app
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - ./backend:/code
+    depends_on:
+      - db
+      - redis
+      - ollama
+    ports:
+      - "8000:8000"
+  worker:
+    build: ./backend
+    command: celery -A backend.app.tasks worker -B -l info
+    environment:
+      DATABASE_URL: postgresql+psycopg2://app:app@db:5432/app
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - ./backend:/code
+    depends_on:
+      - db
+      - redis
+      - ollama
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+  frontend:
+    build: ./vue
+    command: node server.js
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./vue:/app
+    depends_on:
+      - backend
+volumes:
+  db-data:

--- a/vue/app.js
+++ b/vue/app.js
@@ -1,5 +1,6 @@
 import { createApp, ref } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
 import { useFetch } from './composables/useFetch.js'
+import WikiPage from './components/WikiPage.vue'
 
 createApp({
   setup() {
@@ -31,4 +32,4 @@ createApp({
 
     return { username, password, loading, error, success, submit }
   }
-}).mount('#app')
+}).component('WikiPage', WikiPage).mount('#app')

--- a/vue/components/ChatInterface.vue
+++ b/vue/components/ChatInterface.vue
@@ -7,21 +7,24 @@
 </template>
 <script setup>
 import { ref } from 'vue'
-import { useFetch } from '../composables/useFetch'
 
 const message = ref('')
 const reply = ref('')
 
-const { data, fetchData } = useFetch(
-  '/api/chat',
-  { method: 'POST', headers: { 'Content-Type': 'application/json' } },
-  { debounce: 0 }
-)
 
 async function send() {
-  await fetchData({ body: JSON.stringify({ message: message.value }) })
-  if (data.value) {
-    reply.value = data.value.response
+  reply.value = ''
+  const resp = await fetch('/api/qa/stream', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ question: message.value })
+  })
+  const reader = resp.body.getReader()
+  const decoder = new TextDecoder('utf-8')
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    reply.value += decoder.decode(value)
   }
 }
 </script>

--- a/vue/components/CommandPalette.vue
+++ b/vue/components/CommandPalette.vue
@@ -1,0 +1,23 @@
+<template>
+  <div v-if="open" class="fixed inset-0 bg-black/40 flex items-start justify-center pt-20">
+    <div class="bg-white w-96 p-2 rounded">
+      <input v-model="query" class="border w-full mb-2" placeholder="Search..." />
+      <ul>
+        <li v-for="t in filtered" :key="t" class="p-1 hover:bg-gray-200 cursor-pointer" @click="select(t)">{{ t }}</li>
+      </ul>
+    </div>
+  </div>
+</template>
+<script setup>
+import { ref, computed } from 'vue'
+
+const props = defineProps({ open: Boolean, titles: Array })
+const emits = defineEmits(['select', 'close'])
+const query = ref('')
+const filtered = computed(() => props.titles.filter(t => t.toLowerCase().includes(query.value.toLowerCase())))
+
+function select (t) {
+  emits('select', t)
+  emits('close')
+}
+</script>

--- a/vue/components/FileTree.vue
+++ b/vue/components/FileTree.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="p-2">
+    <ul>
+      <li v-for="f in files" :key="f.id">{{ f.name }}</li>
+    </ul>
+    <!-- placeholder for backlink mini-graph -->
+    <div class="mt-4 h-40 border">Graph</div>
+  </div>
+</template>
+<script setup>
+import { onMounted, ref } from 'vue'
+import { useFetch } from '../composables/useFetch'
+
+const { data: files, fetchData } = useFetch('/api/entries')
+
+onMounted(() => fetchData())
+</script>

--- a/vue/components/SettingsModal.vue
+++ b/vue/components/SettingsModal.vue
@@ -1,0 +1,36 @@
+<template>
+  <div v-if="open" class="fixed inset-0 bg-black/50 flex items-center justify-center">
+    <div class="bg-white p-4 rounded w-64">
+      <h2 class="text-lg mb-2">Settings</h2>
+      <div class="mb-2">
+        <label>Model</label>
+        <input v-model="model" class="border w-full" />
+      </div>
+      <div class="mb-2">
+        <label>Chunk Size</label>
+        <input v-model.number="chunk" type="number" class="border w-full" />
+      </div>
+      <div class="mb-2">
+        <label>Retrieval k</label>
+        <input v-model.number="k" type="number" class="border w-full" />
+      </div>
+      <button @click="save" class="bg-blue-500 text-white px-2 py-1 rounded">Save</button>
+    </div>
+  </div>
+</template>
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({ open: Boolean })
+const emits = defineEmits(['close'])
+const model = ref(localStorage.getItem('model') || 'llama3')
+const chunk = ref(Number(localStorage.getItem('chunk')) || 512)
+const k = ref(Number(localStorage.getItem('k')) || 8)
+
+function save () {
+  localStorage.setItem('model', model.value)
+  localStorage.setItem('chunk', chunk.value)
+  localStorage.setItem('k', k.value)
+  emits('close')
+}
+</script>

--- a/vue/components/WikiPage.vue
+++ b/vue/components/WikiPage.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="flex h-screen">
+    <div class="w-1/3 border-r overflow-auto">
+      <FileTree />
+    </div>
+    <div class="flex-1 flex flex-col">
+      <ChatInterface class="flex-1" />
+    </div>
+    <CommandPalette :open="palette" :titles="titles" @close="palette=false" @select="jump" />
+    <SettingsModal :open="settings" @close="settings=false" />
+  </div>
+</template>
+<script setup>
+import { ref, onMounted } from 'vue'
+import ChatInterface from './ChatInterface.vue'
+import FileTree from './FileTree.vue'
+import CommandPalette from './CommandPalette.vue'
+import SettingsModal from './SettingsModal.vue'
+import { useFetch } from '../composables/useFetch'
+
+const palette = ref(false)
+const settings = ref(false)
+const titles = ref([])
+
+const { data, fetchData } = useFetch('/api/entries')
+
+onMounted(async () => {
+  await fetchData()
+  titles.value = (data.value || []).map(e => e.content.split('\n')[0])
+})
+
+function jump (title) {
+  // placeholder: open note
+  console.log('jump to', title)
+}
+
+window.addEventListener('keydown', e => {
+  if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+    palette.value = true
+  }
+})
+</script>

--- a/vue/index.html
+++ b/vue/index.html
@@ -8,7 +8,7 @@
   <script src="https://unpkg.com/vue@3"></script>
 </head>
 <body class="flex items-center justify-center h-screen bg-gray-100">
-  <div id="app" class="w-80 bg-white p-4 rounded shadow">
+  <div id="app" class="w-80 bg-white p-4 rounded shadow" v-if="!success">
     <form @submit.prevent="submit">
       <div class="mb-4">
         <label class="block mb-1">Username</label>
@@ -25,6 +25,9 @@
       </button>
       <div v-if="success" class="text-green-600 mt-2">Login successful!</div>
     </form>
+  </div>
+  <div v-else class="w-full h-screen">
+    <WikiPage />
   </div>
   <script type="module" src="app.js"></script>
 </body>

--- a/vue/server.js
+++ b/vue/server.js
@@ -1,0 +1,19 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const server = http.createServer((req, res) => {
+  const file = req.url === '/' ? 'index.html' : req.url.slice(1);
+  const filePath = path.join(__dirname, file);
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200);
+    res.end(data);
+  });
+});
+
+server.listen(8080);

--- a/vue/tests/unit/__snapshots__/chat.spec.js.snap
+++ b/vue/tests/unit/__snapshots__/chat.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`ChatInterface > sends message and shows reply 1`] = `
 "<div><input placeholder="Say hi"><button>Send</button>
-  <!--v-if-->
+  <p>hi there</p>
 </div>"
 `;

--- a/vue/tests/unit/chat.spec.js
+++ b/vue/tests/unit/chat.spec.js
@@ -4,7 +4,18 @@ import { describe, it, expect, vi } from 'vitest'
 import flushPromises from 'flush-promises'
 
 global.fetch = vi.fn(() => Promise.resolve({
-  json: () => Promise.resolve({ response: 'hi there' })
+  body: {
+    getReader () {
+      let done = false
+      return {
+        async read () {
+          if (done) return { done: true }
+          done = true
+          return { done: false, value: new TextEncoder().encode('hi there') }
+        }
+      }
+    }
+  }
 }))
 
 describe('ChatInterface', () => {


### PR DESCRIPTION
## Summary
- add Docker Compose stack with Postgres/pgvector, Redis, FastAPI, Celery worker, Ollama and Vue
- provide Makefile `dev` target
- support Postgres in backend configuration
- add import route to handle zipped Markdown/PDF ingestion
- add retrieval QA service with streaming SSE
- schedule nightly digests and backlink updates in Celery
- update Vue front-end with chat streaming and navigation
- document usage in README

## Testing
- `npm install --no-progress`
- `pip install -r backend/requirements.txt`
- `bash scripts/test_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_688482c4e25c83339ebc48952de8e239