### PR TITLE
Add Tauri packaging and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    env:
+      CSC_LINK: ${{ secrets.WINDOWS_CERT }}
+      CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - run: npm install -g @tauri-apps/cli nativefier
+      - run: npm install
+      - name: Build SmartPad frontend
+        run: yarn workspace app build
+      - name: Copy frontend to Tauri crate
+        run: |
+          mkdir -p tauri/dist
+          cp -r app/dist/* tauri/dist/ || true
+      - name: Build signed installer and portable exe
+        run: |
+          cargo tauri build --target x86_64-pc-windows-msvc --bundles msi
+          signtool sign /f "$env:CSC_LINK" /p "$env:CSC_KEY_PASSWORD" "target\x86_64-pc-windows-msvc\release\tauri.exe"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: smartpad-windows
+          path: |
+            target/x86_64-pc-windows-msvc/release/tauri.exe
+            src-tauri/target/release/bundle/msi/*.msi
+      - name: Build nativefier wrapper
+        run: nativefier "https://smartpad.app" nativefier-build -n SmartPad
+      - uses: actions/upload-artifact@v4
+        with:
+          name: smartpad-nativefier
+          path: nativefier-build

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,1 @@
+Placeholder for LLM models

--- a/scripts/build_nativefier.sh
+++ b/scripts/build_nativefier.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+URL=${1:-"https://smartpad.app"}
+OUT_DIR=${2:-nativefier-build}
+npx nativefier "$URL" "$OUT_DIR" -n SmartPad

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -1,0 +1,24 @@
+{
+  "package": {
+    "productName": "SmartPad",
+    "version": "0.1.0"
+  },
+  "build": {
+    "beforeBuildCommand": "yarn workspace app build",
+    "beforeDevCommand": "yarn workspace app dev"
+  },
+  "tauri": {
+    "bundle": {
+      "active": true,
+      "identifier": "com.smartpad.app",
+      "targets": ["msi", "deb"],
+      "resources": ["../models"],
+      "compression": "lzma",
+      "windows": {
+        "wix": {
+          "fragmentPaths": ["wix/file-association.wxs"]
+        }
+      }
+    }
+  }
+}

--- a/tauri/wix/file-association.wxs
+++ b/tauri/wix/file-association.wxs
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <DirectoryRef Id="APPLICATIONFOLDER">
+      <Component Id="SmartPadFileAssoc" Guid="*">
+        <ProgId Id="SmartPad.note" Description="SmartPad Markdown Note" Icon="[#SmartPad.exe]">
+          <Extension Id="smartpad" ContentType="text/markdown">
+            <Verb Id="open" Command="Open" TargetFile="[#SmartPad.exe]" Argument="\"%1\"" />
+          </Extension>
+        </ProgId>
+        <RegistryKey Root="HKCU" Key="Software\Classes\.smartpad" Action="write">
+          <RegistryValue Type="string" Value="SmartPad.note" />
+        </RegistryKey>
+        <RegistryKey Root="HKCU" Key="Software\Classes\smartpad" Action="write">
+          <RegistryValue Type="string" Value="URL:smartpad" />
+          <RegistryValue Type="string" Name="URL Protocol" Value="" />
+          <RegistryKey Id="smartpadopen" Action="write" Key="shell\open\command">
+            <RegistryValue Type="string" Value="[#SmartPad.exe] -- %1" />
+          </RegistryKey>
+        </RegistryKey>
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+</Wix>


### PR DESCRIPTION
## Summary
- set up `tauri.conf.json` with lzma compression and include `models` directory
- register `.smartpad` file extension via WiX fragment
- add script to build Nativefier fallback
- create release workflow for Windows MSI/EXE and Nativefier build
- placeholder models directory

## Testing
- `npm run lint`
- `npm test -- --run`
- `pytest backend/tests/test_bench.py`
- `dotnet run -c Release --project src/Benchmarks/Benchmarks.csproj`
- `python scripts/compare_benchmarkdotnet.py src/Benchmarks/baseline.csv BenchmarkDotNet.Artifacts/results/DapperBenchmarks-report.csv`


------
https://chatgpt.com/codex/tasks/task_e_6884ff14ab208333873c29776ba975e3