### PR TITLE
Add mode selection modal and service worker

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -9,7 +9,7 @@ createApp({
     const success = ref(false)
 
     const { data, error, loading, fetchData } = useFetch(
-      'http://localhost:8000/api/auth/login',
+      '/api/auth/login',
       { method: 'POST', headers: { 'Content-Type': 'application/json' } }
     )
 

--- a/app/index.html
+++ b/app/index.html
@@ -8,6 +8,17 @@
   <script src="https://unpkg.com/vue@3"></script>
 </head>
 <body class="flex items-center justify-center h-screen bg-gray-100">
+  <div id="mode-modal" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden">
+    <div class="bg-white p-4 rounded shadow">
+      <p class="mb-2">Open in Desktop window or Browser tab?</p>
+      <div class="mb-2">
+        <label class="mr-4"><input type="radio" name="mode" value="desktop" class="mr-1">Desktop</label>
+        <label><input type="radio" name="mode" value="browser" class="mr-1">Browser</label>
+      </div>
+      <button id="mode-confirm" class="bg-blue-500 text-white px-3 py-1 rounded">OK</button>
+    </div>
+  </div>
+  <div id="mode-chip" class="fixed top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm cursor-pointer"></div>
   <div id="splash" class="absolute inset-0 flex items-center justify-center bg-gray-100">
     <div id="status">Starting...</div>
   </div>
@@ -34,12 +45,73 @@
   </div>
   <script type="module" src="app.js"></script>
   <script>
+    const chip = document.getElementById('mode-chip')
+    const modal = document.getElementById('mode-modal')
+    const confirmBtn = document.getElementById('mode-confirm')
+
+    const currentMode = location.protocol === 'tauri:' ? 'desktop' : 'browser'
+    chip.textContent = currentMode.charAt(0).toUpperCase() + currentMode.slice(1)
+
+    chip.addEventListener('click', () => {
+      if (window.__TAURI__) {
+        window.__TAURI__.invoke('toggle_mode').then(() => location.reload())
+      }
+    })
+
+    if (!localStorage.getItem('mode-chosen')) {
+      modal.classList.remove('hidden')
+      const input = modal.querySelector(`input[value="${currentMode}"]`)
+      if (input) input.checked = true
+      confirmBtn.addEventListener('click', () => {
+        const choice = modal.querySelector('input[name=mode]:checked').value
+        localStorage.setItem('mode-chosen', 'true')
+        modal.classList.add('hidden')
+        if (choice !== currentMode && window.__TAURI__) {
+          window.__TAURI__.invoke('toggle_mode').then(() => location.reload())
+        }
+      })
+    }
+
     fetch('/status').then(r => r.json()).then(d => {
       document.getElementById('status').textContent = `LLM loaded: ${d.llm_loaded}, docs indexed: ${d.docs_indexed}`;
       setTimeout(() => document.getElementById('splash').style.display = 'none', 1000);
     }).catch(() => {
       document.getElementById('status').textContent = 'Starting...';
     });
+
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js').then(reg => {
+          if (reg.waiting) notifyUpdate(reg.waiting)
+
+          reg.addEventListener('updatefound', () => {
+            const newWorker = reg.installing
+            newWorker.addEventListener('statechange', () => {
+              if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                notifyUpdate(newWorker)
+              }
+            })
+          })
+        })
+      })
+
+      let refreshing = false
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (refreshing) return
+        refreshing = true
+        window.location.reload()
+      })
+    }
+
+    function notifyUpdate (worker) {
+      const n = document.createElement('div')
+      n.className = 'fixed bottom-2 right-2 bg-blue-500 text-white px-3 py-2 rounded cursor-pointer'
+      n.textContent = 'Update available - click to reload'
+      n.addEventListener('click', () => {
+        worker.postMessage({ type: 'SKIP_WAITING' })
+      })
+      document.body.appendChild(n)
+    }
   </script>
 </body>
 </html>

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,0 +1,29 @@
+const CACHE_NAME = 'pwa-cache-v1';
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(resp => {
+        const clone = resp.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        return resp;
+      });
+    })
+  );
+});
+
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});


### PR DESCRIPTION
## Summary
- prompt for Desktop or Browser mode on first run
- display current mode chip that toggles via Tauri
- implement PWA service worker with update notification
- use relative login API path

## Testing
- `npm install`
- `pip install -r backend/requirements.txt`
- `bash scripts/test_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885134a2c5c8333853116389d071824