### PR TITLE
Add separate docs for development and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,173 +1,28 @@
 # FrankTheLocalLLM
 
-This repository contains a minimal front‑end built with Vue.js and Tailwind CSS plus a FastAPI backend and a .NET console application.
+FrankTheLocalLLM combines a Vue.js + Tailwind front‑end with a FastAPI backend and a small .NET console application. It demonstrates how to run a local language‑model driven notes app with background processing and optional desktop packaging.
 
-## Quick Start
+## Features
 
-Clone the repository and launch everything with a single command. The helper
-script automatically installs dependencies, builds the .NET project and starts
-both the backend and frontend:
+- Vue front‑end served via a simple HTTP server
+- FastAPI API exposing chat, retrieval and import endpoints
+- LangChain integration with a local Ollama model
+- Background tasks using Celery and Redis
+- Example .NET console service with SQLite and Dapper
+- Docker Compose stack including Postgres with pgvector
+- Devcontainer configuration for offline development
 
-```bash
-./run_all.sh
-```
-Or clone and launch everything in one step:
-```bash
- git clone <repository-url> FrankTheLocalLLM && cd FrankTheLocalLLM && ./run_all.sh
-```
+## Process Overview
 
-The script starts the .NET console app, installs Python dependencies, launches the FastAPI API and serves the Vue.js front-end.
-Use `./run_logged.sh` if you want the same process to log output to `run.log`.
+1. The Vue front‑end sends requests to the FastAPI backend under `/api`.
+2. Notes are chunked and embedded into Postgres using pgvector.
+3. Retrieval endpoints stream answers from the vector store via LangChain.
+4. Background workers summarize entries and maintain backlinks.
+5. The optional .NET console app demonstrates additional data access patterns.
 
-## Getting Started
+## Documentation
 
-1. Serve the Vue.js front-end from the `vue/` directory:
-   ```bash
-   cd vue
-   python -m http.server 8080
-   ```
+- [Local Development Guide](docs/README-local-dev.md) explains how to run everything unpackaged.
+- [Packaging Guide](docs/README-packaging.md) covers building desktop bundles or Docker images.
 
-   The page will be available at `http://localhost:8080`.
-
-2. In your browser open the served page. The client expects the FastAPI backend
-   to be available at `http://localhost:8000/api`.
-   When started the server tries to bind to port `8000` but if it is already
-   taken the process automatically increments the port until a free one is
-   found. Set the `PORT` environment variable to force a specific port or edit
-   `backend/app/config.py`.
-
-You can modify `vue/index.html` and `vue/app.js` to tweak the UI or add new
-components.
-
-## Docker Compose Stack
-
-Run the full stack in one shot using Docker Compose and the provided Makefile:
-
-```bash
-make dev
-```
-
-This launches Postgres with pgvector, Redis, the FastAPI API plus Celery worker,
-an Ollama instance and the Vue front-end. The `dev` target runs database
-migrations, seeds a sample Markdown note and opens the UI in your browser.
-
-
-## Backend API
-
-A simple FastAPI backend is located in the `backend/` directory. The configuration uses environment variables via `pydantic` and enables CORS.
-
-### Setup
-
-1. Install Python 3.11 or newer.
-2. Install dependencies:
-   ```bash
-   pip install -r backend/requirements.txt
-   ```
-3. Run the server:
-   ```bash
-   python -m backend.app.main
-   ```
-
-The server exposes a sample endpoint at `/api/hello` returning a welcome message.
-
-### Trivia Chain Demo
-
-The backend now includes a simple [LangChain](https://python.langchain.com) setup
-that uses a local LLM provided by [Ollama](https://ollama.ai). A small knowledge
-base lives in `backend/data/trivia.md` and is loaded into a vector store on
-startup. When Ollama is running locally, you can query this data via:
-
-```bash
-curl "http://localhost:8000/api/trivia?q=What is the largest planet?"
-```
-
-Make sure to install the new Python dependencies and have an Ollama model (for
-example `llama3`) available.
-
-### Retrieval QA
-
-The `/api/qa/stream` endpoint streams answers from a LangChain RetrievalQA chain
-backed by pgvector. Results include markdown formatted citations linking to the
-original note.
-
-
-## Console Service
-
-A .NET console application demonstrates SQLite data access using Dapper following a simple clean architecture layout. Projects reside in `src/`.
-
-### Setup
-
-1. Install the .NET SDK 8.0 or newer and verify the version:
-   ```bash
-   dotnet --version
-   ```
-   If the runtime loader complains about a different version (for example 9.0.1) install the matching SDK or update the `TargetFramework` in the project files.
-2. Restore and build the solution (this also installs NuGet packages if needed):
-   ```bash
-   dotnet build src/ConsoleAppSolution.sln -c Release
-   ```
-3. Run the console app:
-   ```bash
-   dotnet run --project src/ConsoleApp/ConsoleApp.csproj
-   ```
-
-If `dotnet restore` warns that vulnerability data cannot be downloaded you can disable the audit by placing a `nuget.config` file next to the solution with:
-
-```xml
-<configuration>
-  <config>
-    <add key="VulnerabilityMode" value="Off" />
-  </config>
-</configuration>
-```
-
-By default the app stores data in `app.db`, creating the database if it does not exist.
-The infrastructure project also exposes a `UserRepository` with async CRUD
-operations powered by Dapper. Migration scripts under
-`src/Infrastructure/Migrations` set up tables for `users`, `entries`, `tasks`
-and `llm_logs`. A simple `user_stats` view provides aggregate counts which the
-repository surfaces via `GetStatsAsync`.
-
-## Dev Container
-
-A `.devcontainer` configuration is provided for offline development.
-It installs Python 3.11, Node.js, the .NET 8 SDK, SQLite and Ollama.
-The container mounts a Docker volume at `/root/.ollama` so models and
-database files persist between sessions.
-
-Launch the environment with the [devcontainer CLI](https://containers.dev/cli):
-
-```bash
-devcontainer up
-```
-
-## Running Everything Together
-
-To build and launch all parts of the project at once run:
-
-```bash
-./run_all.sh
-```
-
-The script sequentially builds the .NET console app, installs Python dependencies, launches the FastAPI API and serves the Vue.js front-end on port 8080. Use `./run_logged.sh` to run the same process with output logged to `run.log`. The backend server stops automatically when you exit the HTTP server.
-On Windows run the commands from `run_all.sh` one by one in PowerShell (first `cd vue`, then `python -m http.server 8080`) or execute the script in WSL. Running them in order ensures all dependencies are restored.
-
-Background tasks that summarize entries can be started separately using
-
-```bash
-celery -A backend.app.tasks worker --beat
-```
-The worker also schedules a nightly digest summarizing new chunks and maintains
-wiki-style backlinks between notes.
-
-### Importing Data
-
-Upload a ZIP archive to `/api/import` containing Markdown or PDF files. The
-server extracts each document, splits it by headings, de-duplicates chunks and
-queues embedding jobs in Celery. Vectors are stored in Postgres using the
-pgvector extension.
-
-
-
-## Testing
-Run `scripts/test_pipeline.sh` to lint frontend code, run vitest and pytest suites and apply SQL migrations in a container. If Docker is not available the migration step is skipped.
+Run `scripts/test_pipeline.sh` to lint and test the codebase.

--- a/docs/README-local-dev.md
+++ b/docs/README-local-dev.md
@@ -1,0 +1,47 @@
+# Local Development Guide
+
+This short guide explains how to run the entire project locally without any packaging step. It is intended for developers who want to test everything from the terminal.
+
+## Prerequisites
+
+- Python 3.11+
+- Node.js (for the Vue frontend)
+- The .NET 8 SDK (optional but recommended)
+
+## Quick Start
+
+Clone the repository and launch the stack with a single command:
+
+```bash
+./run_all.sh
+```
+
+The script will:
+
+1. Build and run the .NET console application if `dotnet` is available.
+2. Install Python dependencies from `backend/requirements.txt` and start the FastAPI API on port 8000.
+3. Serve the Vue.js frontend from `app/` on port 8080.
+
+Use `./run_logged.sh` to log output to `run.log` while running the same processes.
+
+Press `Ctrl+C` in the terminal to stop all services.
+
+## Manual Steps
+
+If you prefer to run each component manually:
+
+```bash
+# Backend
+pip install -r backend/requirements.txt
+python -m backend.app.main
+
+# Frontend
+cd app
+python -m http.server 8080
+
+# .NET console (optional)
+dotnet build src/ConsoleAppSolution.sln -c Release
+dotnet run --project src/ConsoleApp/ConsoleApp.csproj
+```
+
+Open `http://localhost:8080` in your browser to access the UI.

--- a/docs/README-packaging.md
+++ b/docs/README-packaging.md
@@ -1,0 +1,42 @@
+# Packaging Guide
+
+This document explains how to build distributable packages of the project once development is complete.
+
+## Desktop Bundle with Tauri
+
+The repository contains a [Tauri](https://tauri.app) project under `tauri/` that can generate a cross-platform desktop application.
+
+1. Install Rust and the Tauri CLI:
+   ```bash
+   cargo install tauri-cli
+   ```
+2. Build the frontend and copy it into the Tauri crate:
+   ```bash
+   yarn workspace app build
+   mkdir -p tauri/dist
+   cp -r app/dist/* tauri/dist/ || true
+   ```
+3. Build the release bundle:
+   ```bash
+   cargo tauri build
+   ```
+   On Windows you can produce an MSI installer with:
+   ```bash
+   cargo tauri build --target x86_64-pc-windows-msvc --bundles msi
+   ```
+
+Generated binaries can be found under `src-tauri/target/release/bundle`.
+
+## Makefile Convenience Target
+
+Running `make all` will install dependencies, build the frontend and compile the Tauri application in one step.
+
+## Docker Compose
+
+For a containerized deployment you can use the provided `docker-compose.yml`. Build the images and start the stack with:
+
+```bash
+docker compose up --build
+```
+
+This launches Postgres with pgvector, Redis, the FastAPI API, Celery worker, Ollama and the Vue frontend.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
+    "@playwright/test": "^1.54.1",
     "@vitejs/plugin-vue": "^6.0.0",
     "@vue/test-utils": "^2.4.6",
     "cypress": "^14.5.2",
@@ -20,10 +21,10 @@
     "eslint-plugin-vue": "^10.3.0",
     "flush-promises": "^1.0.2",
     "jsdom": "^26.1.0",
+    "playwright": "^1.54.1",
     "vite": "^7.0.6",
     "vitest": "^3.2.4",
     "vue": "^3.5.18",
-    "@playwright/test": "^1.54.1",
-    "playwright": "^1.54.1"
+    "vue-eslint-parser": "^10.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,7 +1110,7 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
-debug@4, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.1:
+debug@4, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -1297,7 +1297,7 @@ eslint-plugin-vue@^10.3.0:
     semver "^7.6.3"
     xml-name-validator "^4.0.0"
 
-eslint-scope@^8.4.0:
+eslint-scope@^8.2.0, eslint-scope@^8.4.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.4.0.tgz#88e646a207fad61436ffa39eb505147200655c82"
   integrity sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==
@@ -1310,7 +1310,7 @@ eslint-visitor-keys@^3.4.3:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint-visitor-keys@^4.2.1:
+eslint-visitor-keys@^4.2.0, eslint-visitor-keys@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
@@ -1356,7 +1356,7 @@ eslint@^9.31.0:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
-espree@^10.0.1, espree@^10.4.0:
+espree@^10.0.1, espree@^10.3.0, espree@^10.4.0:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-10.4.0.tgz#d54f4949d4629005a1fa168d937c3ff1f7e2a837"
   integrity sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==
@@ -1365,7 +1365,7 @@ espree@^10.0.1, espree@^10.4.0:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^4.2.1"
 
-esquery@^1.5.0:
+esquery@^1.5.0, esquery@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.6.0.tgz#91419234f804d852a82dceec3e16cdc22cf9dae7"
   integrity sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==
@@ -2827,6 +2827,18 @@ vue-component-type-helpers@^2.0.0:
   version "2.2.12"
   resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz#5014787aad185a22f460ad469cc51f14524308bc"
   integrity sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==
+
+vue-eslint-parser@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz#cb53f89b14c7f5bf6a95c9532e3b2961ab619d61"
+  integrity sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==
+  dependencies:
+    debug "^4.4.0"
+    eslint-scope "^8.2.0"
+    eslint-visitor-keys "^4.2.0"
+    espree "^10.3.0"
+    esquery "^1.6.0"
+    semver "^7.6.3"
 
 vue@^3.5.18:
   version "3.5.18"


### PR DESCRIPTION
## Summary
- create docs folder with local dev and packaging guides
- streamline main README with an overview and links to the new docs
- add vue-eslint-parser dev dependency so linting works in CI

## Testing
- `scripts/test_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_688530ac62688333bfcc4a8dcd2732e9