### PR TITLE
Add prompt to choose UI launch mode

### DIFF
--- a/docs/README-local-dev.md
+++ b/docs/README-local-dev.md
@@ -21,8 +21,9 @@ The script will:
 1. Build and run the .NET console application if `dotnet` is available.
 2. Install Python dependencies from `backend/requirements.txt` and start the FastAPI API on port 8000.
 3. Serve the Vue.js frontend from `app/` on port 8080.
+4. Prompt you to either open the UI in your browser or launch the Tauri desktop application.
 
-Use `./run_logged.sh` to log output to `run.log` while running the same processes.
+Use `./run_logged.sh` to log output to `run.log` while running the same processes and prompt.
 
 Press `Ctrl+C` in the terminal to stop all services.
 
@@ -44,4 +45,4 @@ dotnet build src/ConsoleAppSolution.sln -c Release
 dotnet run --project src/ConsoleApp/ConsoleApp.csproj
 ```
 
-Open `http://localhost:8080` in your browser to access the UI.
+The default UI is served at `http://localhost:8080`.

--- a/run_all.sh
+++ b/run_all.sh
@@ -39,14 +39,50 @@ pip install -r backend/requirements.txt
 python -m backend.app.main &
 BACKEND_PID=$!
 
-cleanup() {
-  echo "Stopping backend..."
-  [[ -n "$DOTNET_PID" ]] && kill "$DOTNET_PID"
-  kill $BACKEND_PID
-}
-trap cleanup EXIT
-
 # Serve the Vue.js frontend
 
 cd app
-python -m http.server 8080
+python -m http.server 8080 &
+FRONTEND_PID=$!
+cd ..
+
+# Helper to open the default browser on the correct platform
+open_browser() {
+  local url="http://localhost:8080"
+  case "$(uname)" in
+    Darwin*) cmd="open" ;;
+    CYGWIN*|MINGW*|MSYS*) cmd="cmd.exe /c start" ;;
+    *) cmd="xdg-open" ;;
+  esac
+
+  if command -v ${cmd%% *} >/dev/null 2>&1; then
+    $cmd "$url" >/dev/null 2>&1 &
+  else
+    echo "Please open $url in your browser." >&2
+  fi
+}
+
+cleanup() {
+  echo "Stopping backend..."
+  [[ -n "$DOTNET_PID" ]] && kill "$DOTNET_PID"
+  kill $BACKEND_PID $FRONTEND_PID
+}
+trap cleanup EXIT
+
+echo
+echo "Servers are running. How would you like to open the UI?"
+echo "1) Open in browser"
+echo "2) Run Tauri application"
+read -rp "Selection [1/2]: " choice
+
+if [[ $choice == 2 ]]; then
+  if command -v cargo >/dev/null 2>&1; then
+    (cd tauri && cargo tauri dev)
+    exit 0
+  else
+    echo "cargo not found - opening browser instead." >&2
+  fi
+fi
+
+open_browser
+wait

--- a/run_logged.sh
+++ b/run_logged.sh
@@ -61,6 +61,39 @@ echo "[FRONTEND SERVE]"
   FRONTEND_PID=$!
 cd ..
 
+# Helper to open the default browser on the correct platform
+open_browser() {
+  local url="http://localhost:8080"
+  case "$(uname)" in
+    Darwin*) cmd="open" ;;
+    CYGWIN*|MINGW*|MSYS*) cmd="cmd.exe /c start" ;;
+    *) cmd="xdg-open" ;;
+  esac
+
+  if command -v ${cmd%% *} >/dev/null 2>&1; then
+    $cmd "$url" >/dev/null 2>&1 &
+  else
+    echo "Please open $url in your browser." >&2
+  fi
+}
+
+echo
+echo "Servers are running. How would you like to open the UI?"
+echo "1) Open in browser"
+echo "2) Run Tauri application"
+read -rp "Selection [1/2]: " choice
+
+if [[ $choice == 2 ]]; then
+  if command -v cargo >/dev/null 2>&1; then
+    (cd tauri && cargo tauri dev)
+    exit 0
+  else
+    echo "cargo not found - opening browser instead." >&2
+  fi
+fi
+
+open_browser
+
 cleanup() {
   echo "[CLEANUP]"
   [[ -n "$DOTNET_PID" ]] && kill "$DOTNET_PID"


### PR DESCRIPTION
## Summary
- let run scripts prompt to open a browser or run the Tauri app
- mention default `localhost:8080` URL and prompt in docs

## Testing
- `yarn test` *(fails: No test files found, waiting for changes)*

------
https://chatgpt.com/codex/tasks/task_e_68853d2899dc83338c161ab143f70735