### PR TITLE
Hook run_all to frank up/down scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,24 @@ This repository contains a minimal front‑end built with Vue.js and Tailwind CS
 FrankTheLocalLLM combines a Vue.js + Tailwind front‑end with a FastAPI backend and a small .NET console application. It demonstrates how to run a local language‑model driven notes app with background processing and optional desktop packaging.
 
 ## Quick Start
+
+Clone the repository and launch everything with a single command. The wrapper
+script boots all services via `frank_up.sh` and cleans up with `frank_down.sh`
+when you exit:
+
+```bash
+./run_all.sh
+```
+
+You can also manage the stack manually:
+
+```bash
+./frank_up.sh   # start services
+./frank_down.sh # stop services
+```
+
 ## Features
 
-Clone the repository and launch everything with a single command. The helper
-script automatically installs dependencies, builds the .NET project and starts
-both the backend and frontend:
 - Vue front‑end served via a simple HTTP server
 - FastAPI API exposing chat, retrieval and import endpoints
 - LangChain integration with a local Ollama model
@@ -18,17 +31,15 @@ both the backend and frontend:
 - Docker Compose stack including Postgres with pgvector
 - Devcontainer configuration for offline development
 
-```bash
-./run_all.sh
-```
 Or clone and launch everything in one step:
 ```bash
  git clone <repository-url> FrankTheLocalLLM && cd FrankTheLocalLLM && ./run_all.sh
 ```
 ## Process Overview
 
-The script starts the .NET console app, installs Python dependencies, launches the FastAPI API and serves the Vue.js front-end.
-Use `./run_logged.sh` if you want the same process to log output to `run.log`.
+`run_all.sh` delegates to `frank_up.sh` which installs dependencies and launches
+the FastAPI backend, Celery worker and Vue.js front‑end. Use `./run_logged.sh`
+if you want the same process to log output to `run.log`.
 1. The Vue front‑end sends requests to the FastAPI backend under `/api`.
 2. Notes are chunked and embedded into Postgres using pgvector.
 3. Retrieval endpoints stream answers from the vector store via LangChain.

--- a/run_all.sh
+++ b/run_all.sh
@@ -11,40 +11,10 @@ if [[ $EUID -ne 0 ]]; then
   fi
 fi
 
-# Ensure the backend port is free before starting
-free_port() {
-  local port=$1
-  if lsof -ti tcp:"$port" > /dev/null 2>&1; then
-    echo "Port $port in use - terminating process"
-    lsof -ti tcp:"$port" | xargs kill -9
-  fi
-}
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+trap "$ROOT/frank_down.sh" EXIT
 
-free_port 8000
-
-# Build and run the .NET console application if dotnet is available
-if command -v dotnet >/dev/null 2>&1; then
-  dotnet build src/ConsoleAppSolution.sln -c Release
-  dotnet run --project src/ConsoleApp/ConsoleApp.csproj &
-  DOTNET_PID=$!
-else
-  echo "dotnet not found - skipping .NET build" >&2
-  DOTNET_PID=
-fi
-
-# Install backend dependencies and launch the API
-
-pip install -r backend/requirements.txt
-
-python -m backend.app.main &
-BACKEND_PID=$!
-
-# Serve the Vue.js frontend
-
-cd app
-python -m http.server 8080 &
-FRONTEND_PID=$!
-cd ..
+"$ROOT/frank_up.sh"
 
 # Helper to open the default browser on the correct platform
 open_browser() {
@@ -62,22 +32,15 @@ open_browser() {
   fi
 }
 
-cleanup() {
-  echo "Stopping backend..."
-  [[ -n "$DOTNET_PID" ]] && kill "$DOTNET_PID"
-  kill $BACKEND_PID $FRONTEND_PID
-}
-trap cleanup EXIT
-
 echo
-echo "Servers are running. How would you like to open the UI?"
+echo "Services are running. How would you like to open the UI?"
 echo "1) Open in browser"
 echo "2) Run Tauri application"
 read -rp "Selection [1/2]: " choice
 
 if [[ $choice == 2 ]]; then
   if command -v cargo >/dev/null 2>&1; then
-    (cd tauri && cargo tauri dev)
+    (cd "$ROOT/tauri" && cargo tauri dev)
     exit 0
   else
     echo "cargo not found - opening browser instead." >&2
@@ -85,4 +48,7 @@ if [[ $choice == 2 ]]; then
 fi
 
 open_browser
-wait
+
+echo "Press Ctrl+C to stop services."
+while true; do sleep 1; done
+


### PR DESCRIPTION
## Summary
- wrap `run_all.sh` around `frank_up.sh` and auto-cleanup via `frank_down.sh`
- document new start/stop flow in README

## Testing
- `scripts/test_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_689e4874f94883339f5c26ecde22d294