### PR TITLE
Hook run_all to frank scripts and log failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,24 @@ This repository contains a minimal front‑end built with Vue.js and Tailwind CS
 FrankTheLocalLLM combines a Vue.js + Tailwind front‑end with a FastAPI backend and a small .NET console application. It demonstrates how to run a local language‑model driven notes app with background processing and optional desktop packaging.
 
 ## Quick Start
+
+Clone the repository and launch everything with a single command. The wrapper
+script boots all services via `frank_up.sh` and cleans up with `frank_down.sh`
+when you exit:
+
+```bash
+./run_all.sh
+```
+
+You can also manage the stack manually:
+
+```bash
+./frank_up.sh   # start services
+./frank_down.sh # stop services
+```
+
 ## Features
 
-Clone the repository and launch everything with a single command. The helper
-script automatically installs dependencies, builds the .NET project and starts
-both the backend and frontend:
 - Vue front‑end served via a simple HTTP server
 - FastAPI API exposing chat, retrieval and import endpoints
 - LangChain integration with a local Ollama model
@@ -18,17 +31,16 @@ both the backend and frontend:
 - Docker Compose stack including Postgres with pgvector
 - Devcontainer configuration for offline development
 
-```bash
-./run_all.sh
-```
 Or clone and launch everything in one step:
 ```bash
  git clone <repository-url> FrankTheLocalLLM && cd FrankTheLocalLLM && ./run_all.sh
 ```
 ## Process Overview
 
-The script starts the .NET console app, installs Python dependencies, launches the FastAPI API and serves the Vue.js front-end.
-Use `./run_logged.sh` if you want the same process to log output to `run.log`.
+`run_all.sh` delegates to `frank_up.sh` which installs dependencies and launches
+the FastAPI backend, Celery worker and Vue.js front‑end. All output and any
+errors from the bring‑up process are written to `logs/run_all.log` for
+troubleshooting.
 1. The Vue front‑end sends requests to the FastAPI backend under `/api`.
 2. Notes are chunked and embedded into Postgres using pgvector.
 3. Retrieval endpoints stream answers from the vector store via LangChain.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .middleware import ExceptionLoggingMiddleware
+
 from .config import Settings
 from .db import Base, engine
 from .services.example_service import router as example_router
@@ -25,6 +27,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(ExceptionLoggingMiddleware)
 
 # Ensure database tables exist
 Base.metadata.create_all(bind=engine)

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,0 +1,24 @@
+import logging
+import os
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+LOG_FILE = os.getenv("LOG_FILE", "logs/run_all.log")
+os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+
+logger = logging.getLogger("frank")
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
+    handler = logging.FileHandler(LOG_FILE)
+    handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+    logger.addHandler(handler)
+
+
+class ExceptionLoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        try:
+            response = await call_next(request)
+            return response
+        except Exception:
+            logger.exception("Unhandled exception during request")
+            raise


### PR DESCRIPTION
## Summary
- log run_all.sh output and trap errors to logs/run_all.log
- add FastAPI middleware that writes unhandled exceptions to the same log file
- document central log location in README

## Testing
- `scripts/test_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_689e4874f94883339f5c26ecde22d294