### PR TITLE
Handle non-Ubuntu setups and fix command detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ FrankTheLocalLLM combines a Vue.js + Tailwind front‑end with a FastAPI backend
 
 Clone the repository and launch everything with a single command. The wrapper
 script boots all services via `frank_up.sh` and cleans up with `frank_down.sh`
-when you exit:
+when you exit. The bootstrap script currently targets Ubuntu or WSL environments,
+so other operating systems require a different setup:
 
 ```bash
 ./run_all.sh

--- a/frank_up.sh
+++ b/frank_up.sh
@@ -10,13 +10,15 @@ cd "$ROOT"
 mkdir -p logs
 
 # --- Helpers ---
-need_cmd() { command -v "$1" >/dev/null 2>&1 || return 0; }
+# Return 0 if the given command exists, else non-zero
+need_cmd() { command -v "$1" >/dev/null 2>&1; }
 apt_has() { dpkg -s "$1" >/dev/null 2>&1; }
 
 log() { printf "\n==== %s ====\n" "$*"; }
 
 # --- Detect Ubuntu/WSL ---
-if ! grep -qi ubuntu /etc/os-release; then
+# /etc/os-release may be missing in minimal environments; check before grepping
+if [[ ! -r /etc/os-release ]] || ! grep -qi ubuntu /etc/os-release; then
   echo "This bootstrap is tailored for Ubuntu. For other OS, ask me for the macOS/Windows variant."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- exit gracefully when `/etc/os-release` is missing or non-Ubuntu
- fix `need_cmd` so missing commands trigger installs
- note Ubuntu/WSL requirement for `run_all.sh` in README

## Testing
- `scripts/test_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_689e537de4108333a518a52e0841f9d5