### PR TITLE
Check OS before running Ubuntu-specific bootstrap

### DIFF
--- a/frank_up.sh
+++ b/frank_up.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Determine repo root and set up logging
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+
+LOG_DIR="$ROOT/logs"
+LOG_FILE="$LOG_DIR/frank_up.log"
+mkdir -p "$LOG_DIR"
+
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "=== frank_up.sh started at $(date) ==="
+
 # --- Project policy ---
 # NO DOCKER: This project does not use Docker or containers.
 # One-command bring-up: this script installs missing deps, configures, and runs services.
-
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$ROOT"
-mkdir -p logs
 
 # --- Helpers ---
 # Return 0 if the given command exists, else non-zero

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+LOG_DIR="$ROOT/logs"
+LOG_FILE="$LOG_DIR/run_all.log"
+mkdir -p "$LOG_DIR"
+export LOG_FILE
+
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "=== run_all.sh started at $(date) ==="
+
+# Ensure we're running on Ubuntu/WSL; other systems use a different bootstrap
+if [[ ! -r /etc/os-release ]] || ! grep -qi ubuntu /etc/os-release; then
+  echo "This bootstrap is tailored for Ubuntu. For other OS, ask me for the macOS/Windows variant."
+  exit 0
+fi
+
 # Relaunch with sudo if not running as root. If sudo is unavailable continue
 if [[ $EUID -ne 0 ]]; then
   if command -v sudo >/dev/null 2>&1; then
@@ -11,15 +27,6 @@ if [[ $EUID -ne 0 ]]; then
   fi
 fi
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-LOG_DIR="$ROOT/logs"
-LOG_FILE="$LOG_DIR/run_all.log"
-mkdir -p "$LOG_DIR"
-export LOG_FILE
-
-exec > >(tee -a "$LOG_FILE") 2>&1
-
 error_handler() {
   local exit_code=$?
   echo "Error on line $1: $2 (exit code $exit_code)" >&2
@@ -28,6 +35,7 @@ trap 'error_handler ${LINENO} "$BASH_COMMAND"' ERR
 trap "$ROOT/frank_down.sh" EXIT
 
 
+echo "--- Running frank_up.sh ---"
 "$ROOT/frank_up.sh"
 
 # Helper to open the default browser on the correct platform


### PR DESCRIPTION
## Summary
- log run_all.sh from start and record frank_up.sh run
- capture frank_up.sh installation steps to logs/frank_up.log
- exit gracefully with guidance when host is not Ubuntu

## Testing
- `CI=true npm test -- --run`
- `python -m pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_689e558114e88333a98c808880cd4bb4